### PR TITLE
feat#55: complete the  `create_pull` function

### DIFF
--- a/contract/src/interfaces/ipredifi.cairo
+++ b/contract/src/interfaces/ipredifi.cairo
@@ -1,4 +1,4 @@
-use crate::base::types::{Pool, Category};
+use crate::base::types::{PoolOdds, Pool, Category};
 
 #[starknet::interface]
 pub trait IPredifi<TContractState> {
@@ -20,6 +20,9 @@ pub trait IPredifi<TContractState> {
         creatorFee: u8,
         isPrivate: bool,
         category: Category,
-    ) -> bool;
+    ) -> u256;
+
+    fn pool_count(self: @TContractState) -> u256;
+    fn pool_odds(self: @TContractState, pool_id: u256) -> PoolOdds;
 }
 

--- a/contract/src/predifi.cairo
+++ b/contract/src/predifi.cairo
@@ -2,18 +2,24 @@
 pub mod Predifi {
     // Cairo imports
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
-    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
+    };
     // oz imports
 
     // package imports
-    use crate::base::types::{PoolDetails, Pool, Category, Status, UserStake};
+    use crate::base::types::{PoolDetails, PoolOdds, Pool, Category, Status, UserStake};
     use crate::interfaces::ipredifi::IPredifi;
 
+    // 1 STRK in WEI
+    const ONE_STRK: u256 = 1_000_000_000_000_000_000;
 
     #[storage]
     struct Storage {
         pools: Map<u256, PoolDetails>, // pool id to pool details struct
         pool_count: u256, // number of pools available totally
+        pool_odds: Map<u256, PoolOdds>,
         pool_vote: Map<u256, bool>, // pool id to vote
         user_stakes: Map<ContractAddress, UserStake> // Mapping user -> stake details
     }
@@ -40,7 +46,7 @@ pub mod Predifi {
             creatorFee: u8,
             isPrivate: bool,
             category: Category,
-        ) -> bool {
+        ) -> u256 {
             // Validation checks
             assert!(poolStartTime < poolLockTime, "Start time must be before lock time");
             assert!(poolLockTime < poolEndTime, "Lock time must be before end time");
@@ -48,11 +54,80 @@ pub mod Predifi {
             assert!(
                 maxBetAmount >= minBetAmount, "Max bet must be greater than or equal to min bet",
             );
+            let current_time = get_block_timestamp();
+            assert!(current_time < poolStartTime, "Start time must be in the future");
+            assert!(creatorFee <= 100, "Creator fee cannot exceed 100%");
 
-            true
+            // Collect pool creation fee (1 STRK)
+            self.collect_pool_creation_fee(get_caller_address());
+
+            // Generate new pool ID
+            let pool_id = self.pool_count.read() + 1;
+
+            // Create pool details structure
+            let creator_address = get_caller_address();
+            let pool_details = PoolDetails {
+                pool_id,
+                address: creator_address,
+                poolName,
+                poolType,
+                poolDescription,
+                poolImage,
+                poolEventSourceUrl,
+                createdTimeStamp: current_time,
+                poolStartTime,
+                poolLockTime,
+                poolEndTime,
+                option1,
+                option2,
+                minBetAmount,
+                maxBetAmount,
+                creatorFee,
+                status: Status::Active,
+                isPrivate,
+                category,
+                totalBetAmountStrk: 0_u256,
+                totalBetCount: 0_u8,
+                totalStakeOption1: 0_u256,
+                totalStakeOption2: 0_u256,
+                totalSharesOption1: 0_u256,
+                totalSharesOption2: 0_u256,
+                initial_share_price: 5000 // 0.5 in basis points (10000 = 1.0)
+            };
+
+            self.pools.write(pool_id, pool_details);
+            self.pool_count.write(pool_id);
+
+            let initial_odds = PoolOdds {
+                option1_odds: 5000, // 0.5 in decimal (5000/10000)
+                option2_odds: 5000,
+                option1_probability: 5000, // 50% probability
+                option2_probability: 5000,
+                implied_probability1: 5000,
+                implied_probability2: 5000,
+            };
+
+            self.pool_odds.write(pool_id, initial_odds);
+
+            pool_id
+        }
+
+        fn pool_count(self: @ContractState) -> u256 {
+            self.pool_count.read()
+        }
+
+        fn pool_odds(self: @ContractState, pool_id: u256) -> PoolOdds {
+            self.pool_odds.read(pool_id)
         }
     }
 
     #[generate_trait]
-    impl Private of PrivateTrait {}
+    impl Private of PrivateTrait {
+        fn collect_pool_creation_fee(
+            ref self: ContractState, creator: ContractAddress,
+        ) { // TODO: Uncomment code after ERC20 implementation
+        // let strk_token = IErc20Dispatcher { contract_address: self.strk_token_address.read() };
+        // strk_token.transfer_from(creator, get_contract_address(), ONE_STRK);
+        }
+    }
 }

--- a/contract/tests/test_contract.cairo
+++ b/contract/tests/test_contract.cairo
@@ -1,13 +1,9 @@
-use starknet::{ContractAddress, contract_address_const, ClassHash};
-
-use snforge_std::{declare, ContractClassTrait, DeclareResultTrait};
-
-//use starknet::{ContractAddress, SyscallResultTrait};
-//use core::result::ResultTrait;
-//use core::byte_array::ByteArray;
-
 use contract::base::types::{PoolDetails, Pool, Status, Category};
 use contract::interfaces::ipredifi::{IPredifiDispatcher, IPredifiDispatcherTrait};
+
+use snforge_std::{declare, ContractClassTrait, DeclareResultTrait};
+use starknet::{ContractAddress, get_block_timestamp};
+
 
 fn owner() -> ContractAddress {
     'owner'.try_into().unwrap()
@@ -15,17 +11,15 @@ fn owner() -> ContractAddress {
 fn deploy_predifi() -> IPredifiDispatcher {
     let contract_class = declare("Predifi").unwrap().contract_class();
 
-    let mut calldata = array![];
-    owner().serialize(ref calldata);
-    let (contract_address, _) = contract_class.deploy(@calldata).unwrap();
+    let (contract_address, _) = contract_class.deploy(@array![].into()).unwrap();
     (IPredifiDispatcher { contract_address })
 }
 
 
-// #[test]
+#[test]
 fn test_create_pool() {
     let contract = deploy_predifi();
-    let result = contract
+    let pool_id = contract
         .create_pool(
             'Example Pool',
             Pool::WinBet,
@@ -44,5 +38,177 @@ fn test_create_pool() {
             Category::Sports,
         );
 
-    assert!(result == true, "not created");
+    assert!(pool_id != 0, "not created");
+}
+
+#[test]
+#[should_panic(expected: "Start time must be before lock time")]
+fn test_invalid_time_sequence_start_after_lock() {
+    let contract = deploy_predifi();
+    let (
+        poolName,
+        poolType,
+        poolDescription,
+        poolImage,
+        poolEventSourceUrl,
+        _,
+        _,
+        poolEndTime,
+        option1,
+        option2,
+        minBetAmount,
+        maxBetAmount,
+        creatorFee,
+        isPrivate,
+        category,
+    ) =
+        get_default_pool_params();
+
+    let current_time = get_block_timestamp();
+    let invalid_start_time = current_time + 3600; // 1 hour from now
+    let invalid_lock_time = current_time
+        + 1800; // 30 minutes from now (before start), should not be able to lock before starting
+
+    contract
+        .create_pool(
+            poolName,
+            poolType,
+            poolDescription,
+            poolImage,
+            poolEventSourceUrl,
+            invalid_start_time,
+            invalid_lock_time,
+            poolEndTime,
+            option1,
+            option2,
+            minBetAmount,
+            maxBetAmount,
+            creatorFee,
+            isPrivate,
+            category,
+        );
+}
+
+#[test]
+#[should_panic(expected: "Minimum bet must be greater than 0")]
+fn test_zero_min_bet() {
+    let contract = deploy_predifi();
+    let (
+        poolName,
+        poolType,
+        poolDescription,
+        poolImage,
+        poolEventSourceUrl,
+        poolStartTime,
+        poolLockTime,
+        poolEndTime,
+        option1,
+        option2,
+        _,
+        maxBetAmount,
+        creatorFee,
+        isPrivate,
+        category,
+    ) =
+        get_default_pool_params();
+
+    contract
+        .create_pool(
+            poolName,
+            poolType,
+            poolDescription,
+            poolImage,
+            poolEventSourceUrl,
+            poolStartTime,
+            poolLockTime,
+            poolEndTime,
+            option1,
+            option2,
+            0,
+            maxBetAmount,
+            creatorFee,
+            isPrivate,
+            category,
+        );
+}
+
+#[test]
+#[should_panic(expected: "Creator fee cannot exceed 100%")]
+fn test_excessive_creator_fee() {
+    let contract = deploy_predifi();
+    let (
+        poolName,
+        poolType,
+        poolDescription,
+        poolImage,
+        poolEventSourceUrl,
+        poolStartTime,
+        poolLockTime,
+        poolEndTime,
+        option1,
+        option2,
+        minBetAmount,
+        maxBetAmount,
+        _,
+        isPrivate,
+        category,
+    ) =
+        get_default_pool_params();
+
+    contract
+        .create_pool(
+            poolName,
+            poolType,
+            poolDescription,
+            poolImage,
+            poolEventSourceUrl,
+            poolStartTime,
+            poolLockTime,
+            poolEndTime,
+            option1,
+            option2,
+            minBetAmount,
+            maxBetAmount,
+            101,
+            isPrivate,
+            category,
+        );
+}
+
+
+fn get_default_pool_params() -> (
+    felt252,
+    Pool,
+    ByteArray,
+    ByteArray,
+    ByteArray,
+    u64,
+    u64,
+    u64,
+    felt252,
+    felt252,
+    u256,
+    u256,
+    u8,
+    bool,
+    Category,
+) {
+    let current_time = get_block_timestamp();
+    (
+        'Default Pool', // poolName
+        Pool::WinBet, // poolType
+        "Default Description", // poolDescription
+        "default_image.jpg", // poolImage
+        "https://example.com", // poolEventSourceUrl
+        current_time + 86400, // poolStartTime (1 day from now)
+        current_time + 172800, // poolLockTime (2 days from now)
+        current_time + 259200, // poolEndTime (3 days from now)
+        'Option A', // option1
+        'Option B', // option2
+        1_000_000_000_000_000_000, // minBetAmount (1 STRK)
+        10_000_000_000_000_000_000, // maxBetAmount (10 STRK)
+        5, // creatorFee (5%)
+        false, // isPrivate
+        Category::Sports // category
+    )
 }


### PR DESCRIPTION
## Related issue #55 

## PR Description

`create_pool` function implementation:
- Changed the return type to the created pool's id
- Set initial odds to 0.5 (50/50) for each side of the pool as specified in #55 
- Added a pool creation fee function*
- Added view functions `pool_count()` and `pool_odds()` to help with testing
- Implemented pool creation integration tests

**NOTE: as there is no ERC20 implemented yet I left the internal `collect_pool_creation_fee` function commented, it would just need to be uncommented to easily implement it.

Please let me know if you would like me to modify anything or add more test cases.