### PR TITLE
feat: add update_pool_state function and corresponding event for pool state management

### DIFF
--- a/contract/src/interfaces/ipredifi.cairo
+++ b/contract/src/interfaces/ipredifi.cairo
@@ -1,5 +1,5 @@
 use starknet::ContractAddress;
-use crate::base::types::{Category, Pool, PoolDetails, PoolOdds, UserStake};
+use crate::base::types::{Category, Pool, PoolDetails, PoolOdds, Status, UserStake};
 #[starknet::interface]
 pub trait IPredifi<TContractState> {
     // Pool Creation and Management
@@ -35,5 +35,6 @@ pub trait IPredifi<TContractState> {
     fn get_pool_creator(self: @TContractState, pool_id: u256) -> ContractAddress;
     fn get_creator_fee_percentage(self: @TContractState, pool_id: u256) -> u8;
     fn get_validator_fee_percentage(self: @TContractState, pool_id: u256) -> u8;
+    fn update_pool_state(ref self: TContractState, pool_id: u256) -> Status;
 }
 

--- a/contract/src/predifi.cairo
+++ b/contract/src/predifi.cairo
@@ -325,10 +325,10 @@ pub mod Predifi {
             // Get the pool details
             let pool = self.pools.read(pool_id);
             assert(pool.exists, 'Pool does not exist');
-            
+
             // Get current timestamp
             let current_time = get_block_timestamp();
-            
+
             // Store previous state for event emission
             let previous_state = pool.status;
             let new_state = match pool.status {
@@ -355,26 +355,27 @@ pub mod Predifi {
                 },
                 Status::Closed => Status::Closed,
             };
-            
+
             // If state has changed, update storage and emit event
             if new_state != previous_state {
                 // Create a new PoolDetails with updated status
                 let mut updated_pool = pool;
                 updated_pool.status = new_state;
                 self.pools.write(pool_id, updated_pool);
-                
+
                 // Emit state change event
-                self.emit(
-                    PoolStateUpdated {
-                        pool_id,
-                        previous_state,
-                        new_state,
-                        updated_by: get_caller_address(),
-                        timestamp: current_time,
-                    }
-                );
+                self
+                    .emit(
+                        PoolStateUpdated {
+                            pool_id,
+                            previous_state,
+                            new_state,
+                            updated_by: get_caller_address(),
+                            timestamp: current_time,
+                        },
+                    );
             }
-            
+
             new_state
         }
     }

--- a/contract/tests/test_contract.cairo
+++ b/contract/tests/test_contract.cairo
@@ -8,8 +8,8 @@ use core::felt252;
 use core::serde::Serde;
 use core::traits::{Into, TryInto};
 use snforge_std::{
-    ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
-    stop_cheat_caller_address, test_address,
+    ContractClassTrait, DeclareResultTrait, declare, start_cheat_block_timestamp,
+    start_cheat_caller_address, stop_cheat_block_timestamp, stop_cheat_caller_address, test_address,
 };
 use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 use starknet::{
@@ -707,12 +707,11 @@ fn test_set_pragma_contract_zero_addr() {
 #[test]
 fn test_update_pool_state_logic() {
     let contract = deploy_predifi();
-    
-    // Create a pool with past times to ensure specific states
-    // This allows us to test the state transition logic without manipulating time
+
+    // Get current time
     let current_time = get_block_timestamp();
-    
-    // Create first pool - should be in Active state (start time in future)
+
+    // Create a pool with specific timestamps
     let active_pool_id = contract
         .create_pool(
             'Active Pool',
@@ -731,26 +730,36 @@ fn test_update_pool_state_logic() {
             false,
             Category::Sports,
         );
-    
+
     // Verify initial state
     let pool = contract.get_pool(active_pool_id);
     assert(pool.status == Status::Active, 'Initial state should be Active');
-    
-    // Since we can't manipulate time in tests, we'll verify the function logic
-    // by calling update_pool_state and ensuring it doesn't change state when
-    // the current time is before lock time
-    let new_state = contract.update_pool_state(active_pool_id);
-    assert(new_state == Status::Active, 'Should remain Active');
-    
-    // The logic of the update_pool_state function:
-    // Status::Active  -> Status::Locked   when current_time >= poolLockTime
-    // Status::Locked  -> Status::Settled  when current_time >= poolEndTime
-    // Status::Settled -> Status::Closed   when current_time >= poolEndTime + 86400
-    
-    // We can verify the pool parameters were set correctly
-    assert(pool.poolStartTime == current_time + 1000, 'Start time set correctly');
-    assert(pool.poolLockTime == current_time + 2000, 'Lock time set correctly');
-    assert(pool.poolEndTime == current_time + 3000, 'End time set correctly');
-}
 
+    // Test transition: Active -> Locked
+    // Set block timestamp to just after lock time
+    start_cheat_block_timestamp(contract.contract_address, current_time + 2001);
+    let new_state = contract.update_pool_state(active_pool_id);
+    assert(new_state == Status::Locked, 'State should be Locked');
+
+    // Test transition: Locked -> Settled
+    // Set block timestamp to just after end time
+    start_cheat_block_timestamp(contract.contract_address, current_time + 3001);
+    let new_state = contract.update_pool_state(active_pool_id);
+    assert(new_state == Status::Settled, 'State should be Settled');
+
+    // Test transition: Settled -> Closed
+    // Set block timestamp to 24 hours + 1 second after end time
+    start_cheat_block_timestamp(contract.contract_address, current_time + 3000 + 86401);
+    let new_state = contract.update_pool_state(active_pool_id);
+    assert(new_state == Status::Closed, 'State should be Closed');
+
+    // Test that no further transitions occur once Closed
+    // Set block timestamp to 48 hours after end time
+    start_cheat_block_timestamp(contract.contract_address, current_time + 3000 + 172800);
+    let new_state = contract.update_pool_state(active_pool_id);
+    assert(new_state == Status::Closed, 'Should remain Closed');
+
+    // Reset block timestamp cheat
+    stop_cheat_block_timestamp(contract.contract_address);
+}
 


### PR DESCRIPTION
# Pool State Transition: Automatic State Updates
close #118 
## Overview
This PR implements the automatic pool state transition mechanism to ensure pools transition correctly between their lifecycle states based on timestamps.

## Changes
- Added `update_pool_state` function to check and update pool state based on time conditions
- Added `PoolStateUpdated` event to track state transitions
- Used a match pattern to efficiently handle state transitions
- Added unit test to verify state update logic

## Implementation Details
The pool lifecycle (Active → Locked → Settled → Closed) now automatically updates based on timestamp comparisons:

- **Active → Locked**: When current time ≥ pool lock time
- **Locked → Settled**: When current time ≥ pool end time
- **Settled → Closed**: 24 hours after pool end time

The implementation uses a `match` statement to:
- Reduce code complexity
- Provide cleaner state transition logic
- Improve readability

## Testing
Added `test_update_pool_state_logic` that verifies:
- Initial pool state is Active
- State transition conditions are correctly defined
- Pool parameters are properly set and maintained

## Impact
- Frontends can now call `update_pool_state` to synchronize pool states
- Applications can listen for `PoolStateUpdated` events for real-time updates
- Eliminates need for manual intervention in normal state transitions