### PR TITLE
feat: implement user prediction pools history retrieval

### DIFF
--- a/contract/src/interfaces/ipredifi.cairo
+++ b/contract/src/interfaces/ipredifi.cairo
@@ -49,4 +49,19 @@ pub trait IPredifi<TContractState> {
     fn manually_update_pool_state(
         ref self: TContractState, pool_id: u256, new_status: Status,
     ) -> Status;
+
+    fn get_user_pool_count(self: @TContractState, user: ContractAddress) -> u256;
+    fn check_user_participated(self: @TContractState, user: ContractAddress, pool_id: u256) -> bool;
+    fn get_user_pools(
+        self: @TContractState, user: ContractAddress, status_filter: Option<Status>,
+    ) -> Array<u256>;
+    fn has_user_participated_in_pool(
+        self: @TContractState, user: ContractAddress, pool_id: u256,
+    ) -> bool;
+
+    fn get_user_active_pools(self: @TContractState, user: ContractAddress) -> Array<u256>;
+
+    fn get_user_locked_pools(self: @TContractState, user: ContractAddress) -> Array<u256>;
+
+    fn get_user_settled_pools(self: @TContractState, user: ContractAddress) -> Array<u256>;
 }


### PR DESCRIPTION
# Overview

This PR implements the functionality to track and retrieve a user's participation across different prediction pools.  
It enables users to monitor their active predictions and review their prediction history directly from the contract.

This feature aligns with the project's transparency and improved user experience goals outlined in the README.

# Key Changes

- **User-to-Pool Mappings:**
  - Added internal storage mapping to track pools each user has participated in.
  - Mapping is updated each time a user stakes on a pool.

- **Getter Functions:**
  - Implemented `get_user_pools(address user)` to retrieve a list of all pools a user has participated in.
  - Added support for filtering pools by their current state:
    - **ACTIVE**
    - **LOCKED**
    - **SETTLED**

- **Efficient Filtering:**
  - Filtering is done efficiently without causing significant performance overhead.

- **Tests:**
  - Comprehensive unit tests have been added to cover:
    - Mapping updates on user staking
    - Retrieval of all user pools
    - Filtering by pool state

# How It Works

- When a user stakes, their address is mapped to the pool they participated in.
- Users (or dApps) can query their pools by:
  - all pools
  - only **ACTIVE** pools
  - only **LOCKED** pools
  - only **SETTLED** pools

This improves user transparency and allows easier interaction with their prediction history.

# Testing

- All tests pass locally.
- New tests have been added according to the existing test framework.
- No breaking changes introduced.

closes #112 