### PR TITLE
feat: implement the auto-assign validators to new prediction pool

### DIFF
--- a/contract/src/interfaces/ipredifi.cairo
+++ b/contract/src/interfaces/ipredifi.cairo
@@ -64,4 +64,16 @@ pub trait IPredifi<TContractState> {
     fn get_user_locked_pools(self: @TContractState, user: ContractAddress) -> Array<u256>;
 
     fn get_user_settled_pools(self: @TContractState, user: ContractAddress) -> Array<u256>;
+
+    fn get_pool_validators(
+        self: @TContractState, pool_id: u256,
+    ) -> (ContractAddress, ContractAddress);
+
+    fn assign_random_validators(ref self: TContractState, pool_id: u256);
+    fn assign_validators(
+        ref self: TContractState,
+        pool_id: u256,
+        validator1: ContractAddress,
+        validator2: ContractAddress,
+    );
 }

--- a/contract/tests/test_contract.cairo
+++ b/contract/tests/test_contract.cairo
@@ -2472,7 +2472,7 @@ fn test_assign_random_validators_initial_validator() {
     let (assigned_validator1, assigned_validator2) = contract.get_pool_validators(pool_id);
 
     // Verify that both assigned validators are the expected validator
-    assert(assigned_validator1 == expected_validator, 'Should assign initial validator');
+    assert(assigned_validator1 == expected_validator, 'Should assign initial valdator');
     assert(assigned_validator2 == expected_validator, 'Should assign initial validator');
 }
 

--- a/contract/tests/test_contract.cairo
+++ b/contract/tests/test_contract.cairo
@@ -2062,3 +2062,380 @@ fn test_multiple_users_with_status_transitions() {
 
     stop_cheat_block_timestamp(contract.contract_address);
 }
+
+
+//test for automated validation
+
+#[test]
+fn test_assign_random_validators() {
+    // Deploy the contract
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+
+    // Create validators
+    let validator1 = contract_address_const::<'validator1'>();
+    let validator2 = contract_address_const::<'validator2'>();
+    let validator3 = contract_address_const::<'validator3'>();
+    let validator4 = contract_address_const::<'validator4'>();
+    let zero_address: ContractAddress = contract_address_const::<'zero'>();
+
+    // Add validators to the contract
+    let _validators = contract.add_validators(validator1, validator2, validator3, validator4);
+
+    // Set up token approval for pool creation
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+
+    // Create a pool
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+    let pool_id = create_default_pool(contract);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Assign random validators to the pool
+    contract.assign_random_validators(pool_id);
+
+    // Get the assigned validators
+    let (assigned_validator1, assigned_validator2) = contract.get_pool_validators(pool_id);
+
+    // Verify that validators were assigned
+    assert(assigned_validator1 != zero_address, 'Validator1 should be assigned');
+    assert(assigned_validator2 != zero_address, 'Validator2 should be assigned');
+
+    // Verify that the assigned validators are from our added validators
+    let is_valid_validator1 = assigned_validator1 == validator1
+        || assigned_validator1 == validator2
+        || assigned_validator1 == validator3
+        || assigned_validator1 == validator4;
+
+    let is_valid_validator2 = assigned_validator2 == validator1
+        || assigned_validator2 == validator2
+        || assigned_validator2 == validator3
+        || assigned_validator2 == validator4;
+
+    assert(is_valid_validator1, 'Invalid validator1 assigned');
+    assert(is_valid_validator2, 'Invalid validator2 assigned');
+}
+
+#[test]
+fn test_assign_exactly_two_validators() {
+    // Deploy the contract
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+
+    // Create exactly two validators with different addresses
+    let validator1 = contract_address_const::<'validator1'>();
+    let validator2 = contract_address_const::<'validator2'>();
+    let zero_address: ContractAddress = contract_address_const::<'zero'>();
+
+    // Add validators to the contract (overriding any existing validators)
+    contract.add_validators(validator1, validator2, validator1, validator2);
+
+    // Set up token approval for pool creation
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+
+    // Create a pool
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+    let pool_id = create_default_pool(contract);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Assign random validators to the pool
+    contract.assign_random_validators(pool_id);
+
+    // Get the assigned validators
+    let (assigned_validator1, assigned_validator2) = contract.get_pool_validators(pool_id);
+
+    // Verify that validators were assigned
+    assert(assigned_validator1 != zero_address, 'Validator1 should be assigned');
+    assert(assigned_validator2 != zero_address, 'Validator2 should be assigned');
+
+    // Verify that the assigned validators are from our added validators
+    assert(
+        assigned_validator1 == validator1 || assigned_validator1 == validator2,
+        'Invalid validator1 assigned',
+    );
+    assert(
+        assigned_validator2 == validator1 || assigned_validator2 == validator2,
+        'Invalid validator2 assigned',
+    );
+
+    // Create multiple pools to test consistency
+    let num_pools = 3;
+    let mut pool_ids: Array<u256> = ArrayTrait::new();
+
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+
+    // Create additional pools
+    let mut i: u8 = 0;
+    while i < num_pools {
+        let pool_id = create_default_pool(contract);
+        pool_ids.append(pool_id);
+        i += 1;
+    }
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Assign validators to all pools
+    let mut j: u8 = 0;
+    while j < num_pools {
+        let pool_id = *pool_ids.at(j.into());
+        contract.assign_random_validators(pool_id);
+        j += 1;
+    }
+
+    // Verify all pools have valid validators assigned
+    let mut k: u8 = 0;
+    while k < num_pools {
+        let pool_id = *pool_ids.at(k.into());
+        let (pool_validator1, pool_validator2) = contract.get_pool_validators(pool_id);
+
+        // Verify validators are assigned
+        assert(pool_validator1 != zero_address, 'Pool validator1 not assigned');
+        assert(pool_validator2 != zero_address, 'Pool validator2 not assigned');
+
+        // Verify validators are from our added validators
+        assert(
+            pool_validator1 == validator1 || pool_validator1 == validator2,
+            'Invalid pool validator1',
+        );
+        assert(
+            pool_validator2 == validator1 || pool_validator2 == validator2,
+            'Invalid pool validator2',
+        );
+
+        k += 1;
+    }
+}
+
+#[test]
+fn test_assign_multiple_validators() {
+    // Deploy the contract
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+
+    // Create multiple validators with different addresses
+    let validator1 = contract_address_const::<'validator1'>();
+    let validator2 = contract_address_const::<'validator2'>();
+    let validator3 = contract_address_const::<'validator3'>();
+    let validator4 = contract_address_const::<'validator4'>();
+
+    // Add validators to the contract
+    contract.add_validators(validator1, validator2, validator3, validator4);
+
+    // Set up token approval for pool creation
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 1_000_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+
+    // Get current timestamp
+    let current_time = get_block_timestamp();
+
+    // Create multiple pools
+    let mut pool_ids: Array<u256> = ArrayTrait::new();
+    let num_pools = 5;
+
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+
+    // Create 5 different pools
+    let mut i: u8 = 0;
+    while i < num_pools {
+        let pool_id = contract
+            .create_pool(
+                'Test Pool', // poolName
+                Pool::WinBet, // poolType
+                "Test pool description", // poolDescription
+                "image.jpg", // poolImage
+                "https://example.com", // poolEventSourceUrl
+                current_time + 50, // poolStartTime (future)
+                current_time + 150, // poolLockTime (future)
+                current_time + 1000, // poolEndTime (future)
+                'Yes', // option1
+                'No', // option2
+                1_000_000_000_000_000_000, // minBetAmount (1 token)
+                100_000_000_000_000_000_000, // maxBetAmount (100 tokens)
+                5, // creatorFee (5%)
+                false, // isPrivate
+                Category::Sports // category
+            );
+        pool_ids.append(pool_id);
+        i += 1;
+    }
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Assign validators to each pool
+    let mut i: u32 = 0;
+    while i < pool_ids.len() {
+        let pool_id = *pool_ids.at(i);
+        contract.assign_random_validators(pool_id);
+        i += 1;
+    }
+
+    // Check that validators are distributed across pools
+    // We should see different validators assigned to different pools
+    let mut validator1_count = 0_u8;
+    let mut validator2_count = 0_u8;
+    let mut validator3_count = 0_u8;
+    let mut validator4_count = 0_u8;
+
+    let mut i: u32 = 0;
+    while i < pool_ids.len() {
+        let pool_id = *pool_ids.at(i);
+        let (assigned_validator1, assigned_validator2) = contract.get_pool_validators(pool_id);
+
+        // Count how many times each validator is assigned
+        if assigned_validator1 == validator1 || assigned_validator2 == validator1 {
+            validator1_count += 1;
+        }
+
+        if assigned_validator1 == validator2 || assigned_validator2 == validator2 {
+            validator2_count += 1;
+        }
+
+        if assigned_validator1 == validator3 || assigned_validator2 == validator3 {
+            validator3_count += 1;
+        }
+
+        if assigned_validator1 == validator4 || assigned_validator2 == validator4 {
+            validator4_count += 1;
+        }
+
+        i += 1;
+    }
+
+    // Verify that at least 3 different validators were used
+    // This is a simple check to ensure some level of distribution
+    let mut validators_used = 0;
+    if validator1_count > 0 {
+        validators_used += 1;
+    }
+    if validator2_count > 0 {
+        validators_used += 1;
+    }
+    if validator3_count > 0 {
+        validators_used += 1;
+    }
+    if validator4_count > 0 {
+        validators_used += 1;
+    }
+
+    // With 5 pools and 4 validators, we should see at least 3 different validators used
+    assert(validators_used >= 3_u8, 'Not enough validators used');
+}
+
+#[test]
+fn test_limited_validators_assignment() {
+    // Deploy the contract
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+
+    // Create just one validator
+    let single_validator = contract_address_const::<'single_validator'>();
+
+    // Add only one validator to the contract
+    contract.add_validators(single_validator, single_validator, single_validator, single_validator);
+
+    // Set up token approval for pool creation
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 1_000_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+
+    // Get current timestamp
+    let current_time = get_block_timestamp();
+
+    // Create multiple pools
+    let mut pool_ids: Array<u256> = ArrayTrait::new();
+    let num_pools = 3;
+
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+
+    // Create 3 different pools
+    let mut i: u8 = 0;
+    while i < num_pools {
+        let pool_id = contract
+            .create_pool(
+                'Limited Test Pool', // poolName
+                Pool::WinBet, // poolType
+                "Testing limited validators", // poolDescription
+                "image.jpg", // poolImage
+                "https://example.com", // poolEventSourceUrl
+                current_time + 50, // poolStartTime (future)
+                current_time + 150, // poolLockTime (future)
+                current_time + 1000, // poolEndTime (future)
+                'Yes', // option1
+                'No', // option2
+                1_000_000_000_000_000_000, // minBetAmount (1 token)
+                100_000_000_000_000_000_000, // maxBetAmount (100 tokens)
+                5, // creatorFee (5%)
+                false, // isPrivate
+                Category::Sports // category
+            );
+        pool_ids.append(pool_id);
+        i += 1;
+    }
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Assign validators to each pool
+    let mut i: u32 = 0;
+    while i < pool_ids.len() {
+        let pool_id = *pool_ids.at(i);
+        contract.assign_random_validators(pool_id);
+        i += 1;
+    }
+
+    // Check that all pools have the same validator assigned
+    // Since there's only one validator, it should be assigned to all pools
+    let mut i: u32 = 0;
+    while i < pool_ids.len() {
+        let pool_id = *pool_ids.at(i);
+        let (assigned_validator1, assigned_validator2) = contract.get_pool_validators(pool_id);
+
+        // Both validator1 and validator2 should be the single validator we added
+        assert(assigned_validator1 == single_validator, 'Wrong validator1 assigned');
+        assert(assigned_validator2 == single_validator, 'Wrong validator2 assigned');
+
+        i += 1;
+    }
+
+    // Now add a second validator and verify it gets used for new pools
+    let second_validator = contract_address_const::<'second_validator'>();
+
+    // Clear validators and add two different ones
+    contract.add_validators(single_validator, second_validator, single_validator, second_validator);
+
+    // Create one more pool
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+    let new_pool_id = contract
+        .create_pool(
+            'New Pool', // poolName
+            Pool::WinBet, // poolType
+            "Testing with two validators", // poolDescription
+            "image.jpg", // poolImage
+            "https://example.com", // poolEventSourceUrl
+            current_time + 50, // poolStartTime (future)
+            current_time + 150, // poolLockTime (future)
+            current_time + 1000, // poolEndTime (future)
+            'Yes', // option1
+            'No', // option2
+            1_000_000_000_000_000_000, // minBetAmount (1 token)
+            100_000_000_000_000_000_000, // maxBetAmount (100 tokens)
+            5, // creatorFee (5%)
+            false, // isPrivate
+            Category::Sports // category
+        );
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Assign validators to the new pool
+    contract.assign_random_validators(new_pool_id);
+
+    // Check that the new pool has different validators assigned
+    let (new_assigned_validator1, new_assigned_validator2) = contract
+        .get_pool_validators(new_pool_id);
+
+    // At least one of the validators should be the second validator
+    let has_second_validator = new_assigned_validator1 == second_validator
+        || new_assigned_validator2 == second_validator;
+
+    assert(has_second_validator, 'Second validator not used');
+}
+


### PR DESCRIPTION
This PR introduces the validate_pool function, enabling assigned validators to confirm the correct outcome of a prediction pool. This feature ensures fair reward distribution based on validated results and consensus.

Key Features
Validator-Only Access: Only assigned validators can invoke validate_pool for a specific pool.
State Enforcement: Validation is only accepted when the pool is in the LOCKED state.
Decision Tracking: Individual validator decisions are recorded.
Technical Highlights
Validator identity is strictly checked against the pool’s assigned validator list.
Full compliance with project code style and event emission patterns.
Supports extensibility for additional consensus mechanisms in future versions.

pr for issue implement the auto-assign validators to new prediction pool #113 

issue: #113   