### PR TITLE
Feature/Implement Role-Based Access Controls 

### DIFF
--- a/contract/src/interfaces/ipredifi.cairo
+++ b/contract/src/interfaces/ipredifi.cairo
@@ -38,13 +38,6 @@ pub trait IPredifi<TContractState> {
     fn calculate_validator_fee(ref self: TContractState, pool_id: u256, total_amount: u256) -> u256;
     fn distribute_validator_fees(ref self: TContractState, pool_id: u256);
     fn retrieve_validator_fee(self: @TContractState, pool_id: u256) -> u256;
-    fn add_validators(
-        ref self: TContractState,
-        validator1: ContractAddress,
-        validator2: ContractAddress,
-        validator3: ContractAddress,
-        validator4: ContractAddress,
-    ) -> Array<ContractAddress>;
     fn update_pool_state(ref self: TContractState, pool_id: u256) -> Status;
     fn manually_update_pool_state(
         ref self: TContractState, pool_id: u256, new_status: Status,
@@ -76,6 +69,10 @@ pub trait IPredifi<TContractState> {
         validator1: ContractAddress,
         validator2: ContractAddress,
     );
+    fn add_validator(ref self: TContractState, address: ContractAddress);
+    fn remove_validator(ref self: TContractState, address: ContractAddress);
+    fn is_validator(self: @TContractState, address: ContractAddress) -> bool;
+    fn get_all_validators(self: @TContractState) -> Array<ContractAddress>;
     // Functions for filtering pools by status
     fn get_active_pools(self: @TContractState) -> Array<PoolDetails>;
     fn get_locked_pools(self: @TContractState) -> Array<PoolDetails>;


### PR DESCRIPTION
This PR implements setup and secure management of validator roles as requested in issue #121 

## Implementation Details

This implementation includes:

- Add: `DEFAULT_ADMIN_ROLE` from OpenZeppelin's AccessControl module. An account with this role can manage any other role.

- Remove: `ADMIN_ROLE` as it's redundant with `DEFAULT_ADMIN_ROLE`. We could have kept it and used `set_role_admin` to give `ADMIN_ROLE` the `DEFAULT_ADMIN_ROLE`, but there would be no benefit to this additional logic.

- Add: `fn add_validator(ref self: TContractState, address: ContractAddress)`. This function is callable only by `DEFAULT_ADMIN_ROLE`, grants `VALIDATOR_ROLE` to a given address, and stores this address in the `validators` storage variable. An event is emitted containing the caller and the address added as validator.

- Remove: `add_validators` function that allowed unrestricted addition of validators.

- Add: `fn remove_validator(ref self: TContractState, address: ContractAddress)`. This function is callable only by `DEFAULT_ADMIN_ROLE.` It revokes `VALIDATOR_ROLE` from the given address and removes it from `validators` storage. An event is emitted containing the caller and the removed address.

- Add: `fn is_validator(self: @TContractState, address: ContractAddress) -> bool` that returns whether a given address is a validator.

- Add: `fn get_all_validators(self: @TContractState) -> Array<ContractAddress>` that returns the list of validators.

- Update: Test cases that used validators now properly initialize with the admin role and use the new validator management functions.

- Add: Complete test coverage for `add_validator` and `remove_validator` functions.

---

I'm staying available if any changes are needed.
