### PR TITLE
feat: Implementation_of_Validator_results_Confirmation_and_Settlement_Mechanism_and_test_149

### DIFF
--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -17,4 +17,9 @@ pub mod Errors {
     pub const POOL_NOT_LOCKED: felt252 = 'Pool is not locked';
     pub const POOL_NOT_SETTLED: felt252 = 'Pool is not settled';
     pub const POOL_NOT_RESOLVED: felt252 = 'Pool is not resolved';
+
+    // Validation Errors
+    pub const VALIDATOR_NOT_AUTHORIZED: felt252 = 'Validator not authorized';
+    pub const VALIDATOR_ALREADY_VALIDATED: felt252 = 'Validator already validated';
+    pub const POOL_NOT_READY_FOR_VALIDATION: felt252 = 'Pool not ready for validation';
 }

--- a/src/interfaces/ipredifi.cairo
+++ b/src/interfaces/ipredifi.cairo
@@ -89,4 +89,14 @@ pub trait IPredifi<TContractState> {
     fn get_suspended_pools(self: @TContractState) -> Array<PoolDetails>;
     fn validate_outcome(ref self: TContractState, pool_id: u256, outcome: bool);
     fn claim_reward(ref self: TContractState, pool_id: u256) -> u256;
+
+    // Pool Validation functionality
+    fn validate_pool_result(ref self: TContractState, pool_id: u256, selected_option: bool);
+    fn get_pool_validation_status(
+        self: @TContractState, pool_id: u256,
+    ) -> (u256, bool, bool); // (validation_count, is_settled, final_outcome)
+    fn get_validator_confirmation(
+        self: @TContractState, pool_id: u256, validator: ContractAddress,
+    ) -> (bool, bool); // (has_validated, selected_option)
+    fn set_required_validator_confirmations(ref self: TContractState, count: u256);
 }

--- a/src/predifi.cairo
+++ b/src/predifi.cairo
@@ -102,7 +102,6 @@ pub mod Predifi {
         pool_dispute_count: Map<u256, u256>,
         pool_previous_status: Map<u256, Status>,
         dispute_threshold: u256,
-        
         // strg strc for Validator confirmation and validation results
         pool_validator_confirmations: Map<
             (u256, ContractAddress), bool,
@@ -261,7 +260,9 @@ pub mod Predifi {
         self.token_addr.write(token_addr);
         self.accesscontrol._grant_role(DEFAULT_ADMIN_ROLE, admin);
         self.dispute_threshold.write(3);
-        self.required_validator_confirmations.write(2); // Require at least 2 validator confirmations to settle
+        self
+            .required_validator_confirmations
+            .write(2); // Require at least 2 validator confirmations to settle
     }
 
     #[abi(embed_v0)]
@@ -1091,9 +1092,10 @@ pub mod Predifi {
 
         // @notice gets pool validation status
         // @param pool_id The ID of the pool to check
-        // @return A tuple containing the validation count, whether the pool is settled, and the final outcome
-        // @dev This function checks the number of validations, whether the pool is settled, and the final outcome
-        // @dev It is used to determine if the pool has reached the required number of confirmations for settlement
+        // @return A tuple containing the validation count, whether the pool is settled, and the
+        // final outcome @dev This function checks the number of validations, whether the pool is
+        // settled, and the final outcome @dev It is used to determine if the pool has reached the
+        // required number of confirmations for settlement
         fn get_pool_validation_status(self: @ContractState, pool_id: u256) -> (u256, bool, bool) {
             let validation_count = self.pool_validation_count.read(pool_id);
             let required_confirmations = self.required_validator_confirmations.read();
@@ -1107,8 +1109,9 @@ pub mod Predifi {
         // @param pool_id The ID of the pool to check
         // @param validator The address of the validator to check
         // @return A tuple containing whether the validator has confirmed and their selected option
-        // @dev This function checks if a specific validator has confirmed their validation for a pool
-        // @dev It is used to track individual validator confirmations and their selected options
+        // @dev This function checks if a specific validator has confirmed their validation for a
+        // pool @dev It is used to track individual validator confirmations and their selected
+        // options
         fn get_validator_confirmation(
             self: @ContractState, pool_id: u256, validator: ContractAddress,
         ) -> (bool, bool) {
@@ -1120,7 +1123,8 @@ pub mod Predifi {
 
         // @notice sets the required number of validator confirmations for a pool
         // @param count The number of confirmations required
-        // @dev This function allows the admin to set the number of required confirmations for a pool
+        // @dev This function allows the admin to set the number of required confirmations for a
+        // pool
         fn set_required_validator_confirmations(ref self: ContractState, count: u256) {
             // Only admin can set this
             self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);

--- a/src/predifi.cairo
+++ b/src/predifi.cairo
@@ -22,8 +22,9 @@ pub mod Predifi {
     };
     use crate::base::errors::Errors::{
         AMOUNT_ABOVE_MAXIMUM, AMOUNT_BELOW_MINIMUM, DISPUTE_ALREADY_RAISED, INACTIVE_POOL,
-        INVALID_POOL_DETAILS, INVALID_POOL_OPTION, POOL_NOT_LOCKED, POOL_NOT_RESOLVED,
-        POOL_NOT_SETTLED, POOL_NOT_SUSPENDED, POOL_SUSPENDED,
+        INVALID_POOL_DETAILS, INVALID_POOL_OPTION, POOL_NOT_LOCKED, POOL_NOT_READY_FOR_VALIDATION,
+        POOL_NOT_RESOLVED, POOL_NOT_SETTLED, POOL_NOT_SUSPENDED, POOL_SUSPENDED,
+        VALIDATOR_ALREADY_VALIDATED, VALIDATOR_NOT_AUTHORIZED,
     };
 
     // package imports
@@ -101,6 +102,19 @@ pub mod Predifi {
         pool_dispute_count: Map<u256, u256>,
         pool_previous_status: Map<u256, Status>,
         dispute_threshold: u256,
+        
+        // strg strc for Validator confirmation and validation results
+        pool_validator_confirmations: Map<
+            (u256, ContractAddress), bool,
+        >, // (pool_id, validator) -> has_validated
+        pool_validation_results: Map<
+            (u256, ContractAddress), bool,
+        >, // (pool_id, validator) -> selected_option
+        pool_validation_count: Map<u256, u256>, // pool_id -> number_of_validations
+        pool_final_outcome: Map<
+            u256, bool,
+        >, // pool_id -> final_outcome (true = option2, false = option1)
+        required_validator_confirmations: u256 // Number of validators needed to settle a pool
     }
 
     // Events
@@ -119,6 +133,9 @@ pub mod Predifi {
         DisputeRaised: DisputeRaised,
         DisputeResolved: DisputeResolved,
         PoolSuspended: PoolSuspended,
+        // Validator events
+        ValidatorResultSubmitted: ValidatorResultSubmitted,
+        PoolAutomaticallySettled: PoolAutomaticallySettled,
         #[flat]
         AccessControlEvent: AccessControlComponent::Event,
         #[flat]
@@ -210,6 +227,23 @@ pub mod Predifi {
         timestamp: u64,
     }
 
+    // Validator event structs
+    #[derive(Drop, starknet::Event)]
+    struct ValidatorResultSubmitted {
+        pool_id: u256,
+        validator: ContractAddress,
+        selected_option: bool,
+        timestamp: u64,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct PoolAutomaticallySettled {
+        pool_id: u256,
+        final_outcome: bool,
+        total_validations: u256,
+        timestamp: u64,
+    }
+
     #[derive(Drop, Hash)]
     struct HashingProperties {
         username: felt252,
@@ -227,6 +261,7 @@ pub mod Predifi {
         self.token_addr.write(token_addr);
         self.accesscontrol._grant_role(DEFAULT_ADMIN_ROLE, admin);
         self.dispute_threshold.write(3);
+        self.required_validator_confirmations.write(2); // Require at least 2 validator confirmations to settle
     }
 
     #[abi(embed_v0)]
@@ -957,6 +992,141 @@ pub mod Predifi {
         fn has_user_disputed(self: @ContractState, pool_id: u256, user: ContractAddress) -> bool {
             self.pool_dispute_users.read((pool_id, user))
         }
+
+        fn validate_pool_result(ref self: ContractState, pool_id: u256, selected_option: bool) {
+            let pool = self.pools.read(pool_id);
+            let caller = get_caller_address();
+
+            // Validation checks
+            assert(pool.exists, INVALID_POOL_DETAILS);
+            assert(pool.status != Status::Suspended, POOL_SUSPENDED);
+
+            // Check if caller is an authorized validator
+            let is_validator = self.accesscontrol.has_role(VALIDATOR_ROLE, caller);
+            assert(is_validator, VALIDATOR_NOT_AUTHORIZED);
+
+            // Check if pool is in a state that can be validated (Locked status)
+            assert(pool.status == Status::Locked, POOL_NOT_READY_FOR_VALIDATION);
+
+            // Check if validator has already validated this pool
+            let has_already_validated = self.pool_validator_confirmations.read((pool_id, caller));
+            assert(!has_already_validated, VALIDATOR_ALREADY_VALIDATED);
+
+            // Check if the selected option is valid (must be true for option2 or false for option1)
+            // Since selected_option is boolean, it's inherently valid
+
+            // Record the validator's confirmation and selection
+            self.pool_validator_confirmations.write((pool_id, caller), true);
+            self.pool_validation_results.write((pool_id, caller), selected_option);
+
+            // Increment validation count
+            let current_count = self.pool_validation_count.read(pool_id);
+            let new_count = current_count + 1;
+            self.pool_validation_count.write(pool_id, new_count);
+
+            // Emit validator result submitted event
+            self
+                .emit(
+                    Event::ValidatorResultSubmitted(
+                        ValidatorResultSubmitted {
+                            pool_id,
+                            validator: caller,
+                            selected_option,
+                            timestamp: get_block_timestamp(),
+                        },
+                    ),
+                );
+
+            // Check if we have reached the required number of confirmations
+            let required_confirmations = self.required_validator_confirmations.read();
+
+            if new_count >= required_confirmations {
+                // Calculate the final outcome based on majority vote
+                let final_outcome = self.calculate_validation_consensus(pool_id, new_count);
+
+                // Store the final outcome
+                self.pool_final_outcome.write(pool_id, final_outcome);
+
+                // Update pool status to Settled
+                let mut updated_pool = pool;
+                updated_pool.status = Status::Settled;
+                self.pools.write(pool_id, updated_pool);
+
+                // Emit pool state transition event
+                self
+                    .emit(
+                        Event::PoolStateTransition(
+                            PoolStateTransition {
+                                pool_id,
+                                previous_status: Status::Locked,
+                                new_status: Status::Settled,
+                                timestamp: get_block_timestamp(),
+                            },
+                        ),
+                    );
+
+                // Emit pool automatically settled event
+                self
+                    .emit(
+                        Event::PoolAutomaticallySettled(
+                            PoolAutomaticallySettled {
+                                pool_id,
+                                final_outcome,
+                                total_validations: new_count,
+                                timestamp: get_block_timestamp(),
+                            },
+                        ),
+                    );
+
+                // Emit pool resolved event for compatibility
+                let total_payout = self.calculate_total_payout(pool_id, final_outcome);
+                self
+                    .emit(
+                        Event::PoolResolved(
+                            PoolResolved { pool_id, winning_option: final_outcome, total_payout },
+                        ),
+                    );
+            }
+        }
+
+        // @notice gets pool validation status
+        // @param pool_id The ID of the pool to check
+        // @return A tuple containing the validation count, whether the pool is settled, and the final outcome
+        // @dev This function checks the number of validations, whether the pool is settled, and the final outcome
+        // @dev It is used to determine if the pool has reached the required number of confirmations for settlement
+        fn get_pool_validation_status(self: @ContractState, pool_id: u256) -> (u256, bool, bool) {
+            let validation_count = self.pool_validation_count.read(pool_id);
+            let required_confirmations = self.required_validator_confirmations.read();
+            let is_settled = validation_count >= required_confirmations;
+            let final_outcome = self.pool_final_outcome.read(pool_id);
+
+            (validation_count, is_settled, final_outcome)
+        }
+
+        // @notice gets validator confirmation status
+        // @param pool_id The ID of the pool to check
+        // @param validator The address of the validator to check
+        // @return A tuple containing whether the validator has confirmed and their selected option
+        // @dev This function checks if a specific validator has confirmed their validation for a pool
+        // @dev It is used to track individual validator confirmations and their selected options
+        fn get_validator_confirmation(
+            self: @ContractState, pool_id: u256, validator: ContractAddress,
+        ) -> (bool, bool) {
+            let has_validated = self.pool_validator_confirmations.read((pool_id, validator));
+            let selected_option = self.pool_validation_results.read((pool_id, validator));
+
+            (has_validated, selected_option)
+        }
+
+        // @notice sets the required number of validator confirmations for a pool
+        // @param count The number of confirmations required
+        // @dev This function allows the admin to set the number of required confirmations for a pool
+        fn set_required_validator_confirmations(ref self: ContractState, count: u256) {
+            // Only admin can set this
+            self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
+            assert(count > 0, 'Count must be greater than 0');
+            self.required_validator_confirmations.write(count);
+        }
     }
 
     #[generate_trait]
@@ -1121,6 +1291,55 @@ pub mod Predifi {
                 i += 1;
             }
             result
+        }
+
+        // Helper functions to calculate the validation consensus
+        fn calculate_validation_consensus(
+            self: @ContractState, pool_id: u256, total_validations: u256,
+        ) -> bool {
+            let mut option1_votes = 0_u256;
+            let mut option2_votes = 0_u256;
+
+            // Get all validators and count their votes
+            let validators = self.get_all_validators();
+            let mut i = 0;
+
+            while i < validators.len() {
+                let validator = *validators.at(i);
+                let has_validated = self.pool_validator_confirmations.read((pool_id, validator));
+
+                if has_validated {
+                    let selected_option = self.pool_validation_results.read((pool_id, validator));
+                    if selected_option {
+                        option2_votes += 1;
+                    } else {
+                        option1_votes += 1;
+                    }
+                }
+                i += 1;
+            }
+
+            // Return true (option2) if option2 has more votes, false (option1) otherwise
+            // In case of tie, default to option1 (false)
+            option2_votes > option1_votes
+        }
+
+        fn calculate_total_payout(
+            self: @ContractState, pool_id: u256, winning_option: bool,
+        ) -> u256 {
+            let pool = self.pools.read(pool_id);
+
+            // Calculate fees
+            let creator_fee_amount = (pool.totalBetAmountStrk * pool.creatorFee.into()) / 100_u256;
+            let validator_fee_amount = self.validator_fee.read(pool_id);
+            let protocol_fee_amount = (pool.totalBetAmountStrk * 5_u256)
+                / 100_u256; // 5% protocol fee
+
+            // Total payout is total bet amount minus all fees
+            let total_fees = creator_fee_amount + validator_fee_amount + protocol_fee_amount;
+            let total_payout = pool.totalBetAmountStrk - total_fees;
+
+            total_payout
         }
     }
 }

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -3466,77 +3466,79 @@ fn test_claim_reward_suspended_pool() {
 #[test]
 fn test_validate_pool_result_success() {
     let (contract, pool_creator, erc20_address) = deploy_predifi();
-    
+
     // Setup ERC20 approval
     let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
     start_cheat_caller_address(erc20_address, pool_creator);
     erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
     stop_cheat_caller_address(erc20_address);
-    
+
     // Create pool
     let current_time = get_block_timestamp();
     start_cheat_caller_address(contract.contract_address, pool_creator);
-    let pool_id = contract.create_pool(
-        'Test Pool',
-        Pool::WinBet,
-        "A test pool for validation",
-        "image.png",
-        "event.com/details",
-        current_time + 100, // Start time
-        current_time + 200, // Lock time  
-        current_time + 300, // End time
-        'Team A',
-        'Team B',
-        100,
-        10000,
-        5,
-        false,
-        Category::Sports,
-    );
+    let pool_id = contract
+        .create_pool(
+            'Test Pool',
+            Pool::WinBet,
+            "A test pool for validation",
+            "image.png",
+            "event.com/details",
+            current_time + 100, // Start time
+            current_time + 200, // Lock time  
+            current_time + 300, // End time
+            'Team A',
+            'Team B',
+            100,
+            10000,
+            5,
+            false,
+            Category::Sports,
+        );
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // Move time to lock the pool
     start_cheat_block_timestamp(contract.contract_address, current_time + 250);
     contract.update_pool_state(pool_id);
     stop_cheat_block_timestamp(contract.contract_address);
-    
+
     // Verify pool is locked
     let locked_pool = contract.get_pool(pool_id);
     assert(locked_pool.status == Status::Locked, 'Pool should be locked');
-    
+
     // Add validators
     let admin = contract_address_const::<'admin'>();
     let validator1 = contract_address_const::<'validator1'>();
     let validator2 = contract_address_const::<'validator2'>();
-    
+
     start_cheat_caller_address(contract.contract_address, admin);
     contract.add_validator(validator1);
     contract.add_validator(validator2);
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // First validator validates - pool should remain locked
     start_cheat_caller_address(contract.contract_address, validator1);
     contract.validate_pool_result(pool_id, true); // Vote for option2
     stop_cheat_caller_address(contract.contract_address);
-    
+
     let pool_after_first_validation = contract.get_pool(pool_id);
     assert(pool_after_first_validation.status == Status::Locked, 'Pool should still be locked');
-    
+
     // Check validation status
     let (validation_count, is_settled, _) = contract.get_pool_validation_status(pool_id);
     assert(validation_count == 1, 'Should have 1 validation');
     assert(!is_settled, 'Pool should not be settled yet');
-    
+
     // Second validator validates - pool should be settled
     start_cheat_caller_address(contract.contract_address, validator2);
     contract.validate_pool_result(pool_id, true); // Vote for option2
     stop_cheat_caller_address(contract.contract_address);
-    
+
     let pool_after_second_validation = contract.get_pool(pool_id);
     assert(pool_after_second_validation.status == Status::Settled, 'Pool should be settled');
-    
+
     // Check final validation status
-    let (final_validation_count, final_is_settled, final_outcome) = contract.get_pool_validation_status(pool_id);
+    let (final_validation_count, final_is_settled, final_outcome) = contract
+        .get_pool_validation_status(pool_id);
     assert(final_validation_count == 2, 'Should have 2 validations');
     assert(final_is_settled, 'Pool should be settled');
     assert(final_outcome, 'Option2 should win');
@@ -3546,23 +3548,23 @@ fn test_validate_pool_result_success() {
 #[should_panic(expected: 'Validator not authorized')]
 fn test_validate_pool_result_unauthorized() {
     let (contract, pool_creator, erc20_address) = deploy_predifi();
-    
+
     // Setup and create pool
     let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
     start_cheat_caller_address(erc20_address, pool_creator);
     erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
     stop_cheat_caller_address(erc20_address);
-    
+
     start_cheat_caller_address(contract.contract_address, pool_creator);
     let pool_id = create_default_pool(contract);
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // Lock the pool
     let current_time = get_block_timestamp();
     start_cheat_block_timestamp(contract.contract_address, current_time + 250);
     contract.update_pool_state(pool_id);
     stop_cheat_block_timestamp(contract.contract_address);
-    
+
     // Try to validate without being a validator
     let unauthorized_user = contract_address_const::<'unauthorized'>();
     start_cheat_caller_address(contract.contract_address, unauthorized_user);
@@ -3573,51 +3575,52 @@ fn test_validate_pool_result_unauthorized() {
 #[should_panic(expected: 'Validator already validated')]
 fn test_validate_pool_result_double_validation() {
     let (contract, pool_creator, erc20_address) = deploy_predifi();
-    
+
     // Setup
     let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
     start_cheat_caller_address(erc20_address, pool_creator);
     erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
     stop_cheat_caller_address(erc20_address);
-    
+
     // Create and lock pool
     let current_time = get_block_timestamp();
     start_cheat_caller_address(contract.contract_address, pool_creator);
-    let pool_id = contract.create_pool(
-        'Test Pool',
-        Pool::WinBet,
-        "A test pool",
-        "image.png",
-        "event.com/details",
-        current_time + 100,
-        current_time + 200,
-        current_time + 300,
-        'Team A',
-        'Team B',
-        100,
-        10000,
-        5,
-        false,
-        Category::Sports,
-    );
+    let pool_id = contract
+        .create_pool(
+            'Test Pool',
+            Pool::WinBet,
+            "A test pool",
+            "image.png",
+            "event.com/details",
+            current_time + 100,
+            current_time + 200,
+            current_time + 300,
+            'Team A',
+            'Team B',
+            100,
+            10000,
+            5,
+            false,
+            Category::Sports,
+        );
     stop_cheat_caller_address(contract.contract_address);
-    
+
     start_cheat_block_timestamp(contract.contract_address, current_time + 250);
     contract.update_pool_state(pool_id);
     stop_cheat_block_timestamp(contract.contract_address);
-    
+
     // Add validator
     let admin = contract_address_const::<'admin'>();
     let validator = contract_address_const::<'validator'>();
-    
+
     start_cheat_caller_address(contract.contract_address, admin);
     contract.add_validator(validator);
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // First validation
     start_cheat_caller_address(contract.contract_address, validator);
     contract.validate_pool_result(pool_id, true);
-    
+
     // Try to validate again - should panic
     contract.validate_pool_result(pool_id, false);
 }
@@ -3626,26 +3629,26 @@ fn test_validate_pool_result_double_validation() {
 #[should_panic(expected: 'Pool not ready for validation')]
 fn test_validate_pool_result_wrong_status() {
     let (contract, pool_creator, erc20_address) = deploy_predifi();
-    
+
     // Setup
     let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
     start_cheat_caller_address(erc20_address, pool_creator);
     erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
     stop_cheat_caller_address(erc20_address);
-    
+
     // Create pool but don't lock it
     start_cheat_caller_address(contract.contract_address, pool_creator);
     let pool_id = create_default_pool(contract);
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // Add validator
     let admin = contract_address_const::<'admin'>();
     let validator = contract_address_const::<'validator'>();
-    
+
     start_cheat_caller_address(contract.contract_address, admin);
     contract.add_validator(validator);
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // Try to validate active pool - should panic
     start_cheat_caller_address(contract.contract_address, validator);
     contract.validate_pool_result(pool_id, true);
@@ -3654,70 +3657,71 @@ fn test_validate_pool_result_wrong_status() {
 #[test]
 fn test_validation_consensus_majority_option1() {
     let (contract, pool_creator, erc20_address) = deploy_predifi();
-    
+
     // Setup
     let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
     start_cheat_caller_address(erc20_address, pool_creator);
     erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
     stop_cheat_caller_address(erc20_address);
-    
+
     // Create and lock pool
     let current_time = get_block_timestamp();
     start_cheat_caller_address(contract.contract_address, pool_creator);
-    let pool_id = contract.create_pool(
-        'Test Pool',
-        Pool::WinBet,
-        "A test pool",
-        "image.png", 
-        "event.com/details",
-        current_time + 100,
-        current_time + 200,
-        current_time + 300,
-        'Team A',
-        'Team B',
-        100,
-        10000,
-        5,
-        false,
-        Category::Sports,
-    );
+    let pool_id = contract
+        .create_pool(
+            'Test Pool',
+            Pool::WinBet,
+            "A test pool",
+            "image.png",
+            "event.com/details",
+            current_time + 100,
+            current_time + 200,
+            current_time + 300,
+            'Team A',
+            'Team B',
+            100,
+            10000,
+            5,
+            false,
+            Category::Sports,
+        );
     stop_cheat_caller_address(contract.contract_address);
-    
+
     start_cheat_block_timestamp(contract.contract_address, current_time + 250);
     contract.update_pool_state(pool_id);
     stop_cheat_block_timestamp(contract.contract_address);
-    
+
     // Add 3 validators and set required confirmations to 3
     let admin = contract_address_const::<'admin'>();
     let validator1 = contract_address_const::<'validator1'>();
     let validator2 = contract_address_const::<'validator2'>();
     let validator3 = contract_address_const::<'validator3'>();
-    
+
     start_cheat_caller_address(contract.contract_address, admin);
     contract.add_validator(validator1);
     contract.add_validator(validator2);
     contract.add_validator(validator3);
     contract.set_required_validator_confirmations(3);
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // Validators vote: 2 for option1 (false), 1 for option2 (true)
     start_cheat_caller_address(contract.contract_address, validator1);
     contract.validate_pool_result(pool_id, false); // Option1
     stop_cheat_caller_address(contract.contract_address);
-    
+
     start_cheat_caller_address(contract.contract_address, validator2);
     contract.validate_pool_result(pool_id, false); // Option1
     stop_cheat_caller_address(contract.contract_address);
-    
+
     start_cheat_caller_address(contract.contract_address, validator3);
     contract.validate_pool_result(pool_id, true); // Option2 - this triggers settlement
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // Check final outcome - should be option1 (false) since it got majority
     let (_, is_settled, final_outcome) = contract.get_pool_validation_status(pool_id);
     assert(is_settled, 'Pool should be settled');
     assert(!final_outcome, 'Option1 should win majority');
-    
+
     let pool = contract.get_pool(pool_id);
     assert(pool.status == Status::Settled, 'Pool should be settled');
 }
@@ -3725,57 +3729,59 @@ fn test_validation_consensus_majority_option1() {
 #[test]
 fn test_get_validator_confirmation() {
     let (contract, pool_creator, erc20_address) = deploy_predifi();
-    
+
     // Setup and create locked pool
     let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
     start_cheat_caller_address(erc20_address, pool_creator);
     erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
     stop_cheat_caller_address(erc20_address);
-    
+
     let current_time = get_block_timestamp();
     start_cheat_caller_address(contract.contract_address, pool_creator);
-    let pool_id = contract.create_pool(
-        'Test Pool',
-        Pool::WinBet,
-        "A test pool",
-        "image.png",
-        "event.com/details", 
-        current_time + 100,
-        current_time + 200,
-        current_time + 300,
-        'Team A',
-        'Team B',
-        100,
-        10000,
-        5,
-        false,
-        Category::Sports,
-    );
+    let pool_id = contract
+        .create_pool(
+            'Test Pool',
+            Pool::WinBet,
+            "A test pool",
+            "image.png",
+            "event.com/details",
+            current_time + 100,
+            current_time + 200,
+            current_time + 300,
+            'Team A',
+            'Team B',
+            100,
+            10000,
+            5,
+            false,
+            Category::Sports,
+        );
     stop_cheat_caller_address(contract.contract_address);
-    
+
     start_cheat_block_timestamp(contract.contract_address, current_time + 250);
     contract.update_pool_state(pool_id);
     stop_cheat_block_timestamp(contract.contract_address);
-    
+
     // Add validator
     let admin = contract_address_const::<'admin'>();
     let validator = contract_address_const::<'validator'>();
-    
+
     start_cheat_caller_address(contract.contract_address, admin);
     contract.add_validator(validator);
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // Check before validation
     let (has_validated, _) = contract.get_validator_confirmation(pool_id, validator);
     assert(!has_validated, 'Should not have validated yet');
-    
+
     // Validate
     start_cheat_caller_address(contract.contract_address, validator);
     contract.validate_pool_result(pool_id, true);
     stop_cheat_caller_address(contract.contract_address);
-    
+
     // Check after validation
-    let (has_validated_after, selected_option) = contract.get_validator_confirmation(pool_id, validator);
+    let (has_validated_after, selected_option) = contract
+        .get_validator_confirmation(pool_id, validator);
     assert(has_validated_after, 'Should have validated');
     assert(selected_option, 'Should have selected option2');
 }

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -3463,3 +3463,319 @@ fn test_claim_reward_suspended_pool() {
     contract.claim_reward(pool_id);
 }
 
+#[test]
+fn test_validate_pool_result_success() {
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+    
+    // Setup ERC20 approval
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+    
+    // Create pool
+    let current_time = get_block_timestamp();
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+    let pool_id = contract.create_pool(
+        'Test Pool',
+        Pool::WinBet,
+        "A test pool for validation",
+        "image.png",
+        "event.com/details",
+        current_time + 100, // Start time
+        current_time + 200, // Lock time  
+        current_time + 300, // End time
+        'Team A',
+        'Team B',
+        100,
+        10000,
+        5,
+        false,
+        Category::Sports,
+    );
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Move time to lock the pool
+    start_cheat_block_timestamp(contract.contract_address, current_time + 250);
+    contract.update_pool_state(pool_id);
+    stop_cheat_block_timestamp(contract.contract_address);
+    
+    // Verify pool is locked
+    let locked_pool = contract.get_pool(pool_id);
+    assert(locked_pool.status == Status::Locked, 'Pool should be locked');
+    
+    // Add validators
+    let admin = contract_address_const::<'admin'>();
+    let validator1 = contract_address_const::<'validator1'>();
+    let validator2 = contract_address_const::<'validator2'>();
+    
+    start_cheat_caller_address(contract.contract_address, admin);
+    contract.add_validator(validator1);
+    contract.add_validator(validator2);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // First validator validates - pool should remain locked
+    start_cheat_caller_address(contract.contract_address, validator1);
+    contract.validate_pool_result(pool_id, true); // Vote for option2
+    stop_cheat_caller_address(contract.contract_address);
+    
+    let pool_after_first_validation = contract.get_pool(pool_id);
+    assert(pool_after_first_validation.status == Status::Locked, 'Pool should still be locked');
+    
+    // Check validation status
+    let (validation_count, is_settled, _) = contract.get_pool_validation_status(pool_id);
+    assert(validation_count == 1, 'Should have 1 validation');
+    assert(!is_settled, 'Pool should not be settled yet');
+    
+    // Second validator validates - pool should be settled
+    start_cheat_caller_address(contract.contract_address, validator2);
+    contract.validate_pool_result(pool_id, true); // Vote for option2
+    stop_cheat_caller_address(contract.contract_address);
+    
+    let pool_after_second_validation = contract.get_pool(pool_id);
+    assert(pool_after_second_validation.status == Status::Settled, 'Pool should be settled');
+    
+    // Check final validation status
+    let (final_validation_count, final_is_settled, final_outcome) = contract.get_pool_validation_status(pool_id);
+    assert(final_validation_count == 2, 'Should have 2 validations');
+    assert(final_is_settled, 'Pool should be settled');
+    assert(final_outcome, 'Option2 should win');
+}
+
+#[test]
+#[should_panic(expected: 'Validator not authorized')]
+fn test_validate_pool_result_unauthorized() {
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+    
+    // Setup and create pool
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+    
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+    let pool_id = create_default_pool(contract);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Lock the pool
+    let current_time = get_block_timestamp();
+    start_cheat_block_timestamp(contract.contract_address, current_time + 250);
+    contract.update_pool_state(pool_id);
+    stop_cheat_block_timestamp(contract.contract_address);
+    
+    // Try to validate without being a validator
+    let unauthorized_user = contract_address_const::<'unauthorized'>();
+    start_cheat_caller_address(contract.contract_address, unauthorized_user);
+    contract.validate_pool_result(pool_id, true);
+}
+
+#[test]
+#[should_panic(expected: 'Validator already validated')]
+fn test_validate_pool_result_double_validation() {
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+    
+    // Setup
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+    
+    // Create and lock pool
+    let current_time = get_block_timestamp();
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+    let pool_id = contract.create_pool(
+        'Test Pool',
+        Pool::WinBet,
+        "A test pool",
+        "image.png",
+        "event.com/details",
+        current_time + 100,
+        current_time + 200,
+        current_time + 300,
+        'Team A',
+        'Team B',
+        100,
+        10000,
+        5,
+        false,
+        Category::Sports,
+    );
+    stop_cheat_caller_address(contract.contract_address);
+    
+    start_cheat_block_timestamp(contract.contract_address, current_time + 250);
+    contract.update_pool_state(pool_id);
+    stop_cheat_block_timestamp(contract.contract_address);
+    
+    // Add validator
+    let admin = contract_address_const::<'admin'>();
+    let validator = contract_address_const::<'validator'>();
+    
+    start_cheat_caller_address(contract.contract_address, admin);
+    contract.add_validator(validator);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // First validation
+    start_cheat_caller_address(contract.contract_address, validator);
+    contract.validate_pool_result(pool_id, true);
+    
+    // Try to validate again - should panic
+    contract.validate_pool_result(pool_id, false);
+}
+
+#[test]
+#[should_panic(expected: 'Pool not ready for validation')]
+fn test_validate_pool_result_wrong_status() {
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+    
+    // Setup
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+    
+    // Create pool but don't lock it
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+    let pool_id = create_default_pool(contract);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Add validator
+    let admin = contract_address_const::<'admin'>();
+    let validator = contract_address_const::<'validator'>();
+    
+    start_cheat_caller_address(contract.contract_address, admin);
+    contract.add_validator(validator);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Try to validate active pool - should panic
+    start_cheat_caller_address(contract.contract_address, validator);
+    contract.validate_pool_result(pool_id, true);
+}
+
+#[test]
+fn test_validation_consensus_majority_option1() {
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+    
+    // Setup
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+    
+    // Create and lock pool
+    let current_time = get_block_timestamp();
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+    let pool_id = contract.create_pool(
+        'Test Pool',
+        Pool::WinBet,
+        "A test pool",
+        "image.png", 
+        "event.com/details",
+        current_time + 100,
+        current_time + 200,
+        current_time + 300,
+        'Team A',
+        'Team B',
+        100,
+        10000,
+        5,
+        false,
+        Category::Sports,
+    );
+    stop_cheat_caller_address(contract.contract_address);
+    
+    start_cheat_block_timestamp(contract.contract_address, current_time + 250);
+    contract.update_pool_state(pool_id);
+    stop_cheat_block_timestamp(contract.contract_address);
+    
+    // Add 3 validators and set required confirmations to 3
+    let admin = contract_address_const::<'admin'>();
+    let validator1 = contract_address_const::<'validator1'>();
+    let validator2 = contract_address_const::<'validator2'>();
+    let validator3 = contract_address_const::<'validator3'>();
+    
+    start_cheat_caller_address(contract.contract_address, admin);
+    contract.add_validator(validator1);
+    contract.add_validator(validator2);
+    contract.add_validator(validator3);
+    contract.set_required_validator_confirmations(3);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Validators vote: 2 for option1 (false), 1 for option2 (true)
+    start_cheat_caller_address(contract.contract_address, validator1);
+    contract.validate_pool_result(pool_id, false); // Option1
+    stop_cheat_caller_address(contract.contract_address);
+    
+    start_cheat_caller_address(contract.contract_address, validator2);
+    contract.validate_pool_result(pool_id, false); // Option1
+    stop_cheat_caller_address(contract.contract_address);
+    
+    start_cheat_caller_address(contract.contract_address, validator3);
+    contract.validate_pool_result(pool_id, true); // Option2 - this triggers settlement
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Check final outcome - should be option1 (false) since it got majority
+    let (_, is_settled, final_outcome) = contract.get_pool_validation_status(pool_id);
+    assert(is_settled, 'Pool should be settled');
+    assert(!final_outcome, 'Option1 should win majority');
+    
+    let pool = contract.get_pool(pool_id);
+    assert(pool.status == Status::Settled, 'Pool should be settled');
+}
+
+#[test]
+fn test_get_validator_confirmation() {
+    let (contract, pool_creator, erc20_address) = deploy_predifi();
+    
+    // Setup and create locked pool
+    let erc20: IERC20Dispatcher = IERC20Dispatcher { contract_address: erc20_address };
+    start_cheat_caller_address(erc20_address, pool_creator);
+    erc20.approve(contract.contract_address, 200_000_000_000_000_000_000_000);
+    stop_cheat_caller_address(erc20_address);
+    
+    let current_time = get_block_timestamp();
+    start_cheat_caller_address(contract.contract_address, pool_creator);
+    let pool_id = contract.create_pool(
+        'Test Pool',
+        Pool::WinBet,
+        "A test pool",
+        "image.png",
+        "event.com/details", 
+        current_time + 100,
+        current_time + 200,
+        current_time + 300,
+        'Team A',
+        'Team B',
+        100,
+        10000,
+        5,
+        false,
+        Category::Sports,
+    );
+    stop_cheat_caller_address(contract.contract_address);
+    
+    start_cheat_block_timestamp(contract.contract_address, current_time + 250);
+    contract.update_pool_state(pool_id);
+    stop_cheat_block_timestamp(contract.contract_address);
+    
+    // Add validator
+    let admin = contract_address_const::<'admin'>();
+    let validator = contract_address_const::<'validator'>();
+    
+    start_cheat_caller_address(contract.contract_address, admin);
+    contract.add_validator(validator);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Check before validation
+    let (has_validated, _) = contract.get_validator_confirmation(pool_id, validator);
+    assert(!has_validated, 'Should not have validated yet');
+    
+    // Validate
+    start_cheat_caller_address(contract.contract_address, validator);
+    contract.validate_pool_result(pool_id, true);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Check after validation
+    let (has_validated_after, selected_option) = contract.get_validator_confirmation(pool_id, validator);
+    assert(has_validated_after, 'Should have validated');
+    assert(selected_option, 'Should have selected option2');
+}


### PR DESCRIPTION
Implemented the `validate_pool_result` function and supporting infrastructure to enable validator pool settlement. It allows validators to confirm prediction outcomes, automatically transtioning pools to `settled` status upon consensus.

Also wrote suitable tests to ensure smooth integrration and functionality closing issue #149 