### PR TITLE
feat: pool_cancellation and stake refund

### DIFF
--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -15,6 +15,7 @@ pub mod Errors {
     pub const DISPUTE_ALREADY_RAISED: felt252 = 'User already raised dispute';
     pub const POOL_NOT_SUSPENDED: felt252 = 'Pool is not suspended';
     pub const POOL_NOT_LOCKED: felt252 = 'Pool is not locked';
+    pub const POOL_NOT_CLOSED: felt252 = 'Pool is not closed';
     pub const POOL_NOT_SETTLED: felt252 = 'Pool is not settled';
     pub const POOL_NOT_RESOLVED: felt252 = 'Pool is not resolved';
 }

--- a/src/interfaces/ipredifi.cairo
+++ b/src/interfaces/ipredifi.cairo
@@ -21,11 +21,13 @@ pub trait IPredifi<TContractState> {
         isPrivate: bool,
         category: Category,
     ) -> u256;
+    fn cancel_pool(ref self: TContractState, pool_id: u256);
     fn pool_count(self: @TContractState) -> u256;
     fn pool_odds(self: @TContractState, pool_id: u256) -> PoolOdds;
     fn get_pool(self: @TContractState, pool_id: u256) -> PoolDetails;
     fn vote(ref self: TContractState, pool_id: u256, option: felt252, amount: u256);
     fn stake(ref self: TContractState, pool_id: u256, amount: u256);
+    fn refund_stake(ref self: TContractState, pool_id: u256);
     fn get_user_stake(self: @TContractState, pool_id: u256, address: ContractAddress) -> UserStake;
     fn get_pool_stakes(self: @TContractState, pool_id: u256) -> UserStake;
     fn get_pool_vote(self: @TContractState, pool_id: u256) -> bool;

--- a/src/predifi.cairo
+++ b/src/predifi.cairo
@@ -22,9 +22,9 @@ pub mod Predifi {
     };
     use crate::base::errors::Errors::{
         AMOUNT_ABOVE_MAXIMUM, AMOUNT_BELOW_MINIMUM, DISPUTE_ALREADY_RAISED, INACTIVE_POOL,
-        INVALID_POOL_DETAILS, INVALID_POOL_OPTION, POOL_NOT_CLOSED, POOL_NOT_LOCKED, POOL_NOT_READY_FOR_VALIDATION,
-        POOL_NOT_RESOLVED, POOL_NOT_SETTLED, POOL_NOT_SUSPENDED, POOL_SUSPENDED,
-        VALIDATOR_ALREADY_VALIDATED, VALIDATOR_NOT_AUTHORIZED,
+        INVALID_POOL_DETAILS, INVALID_POOL_OPTION, POOL_NOT_CLOSED, POOL_NOT_LOCKED,
+        POOL_NOT_READY_FOR_VALIDATION, POOL_NOT_RESOLVED, POOL_NOT_SETTLED, POOL_NOT_SUSPENDED,
+        POOL_SUSPENDED, VALIDATOR_ALREADY_VALIDATED, VALIDATOR_NOT_AUTHORIZED,
     };
 
     // package imports
@@ -238,8 +238,8 @@ pub mod Predifi {
     pub struct PoolCancelled {
         pub pool_id: u256,
         pub timestamp: u64,
-    }    
-    
+    }
+
     // Validator event structs
     #[derive(Drop, starknet::Event)]
     struct ValidatorResultSubmitted {


### PR DESCRIPTION
## ✅ Add Pool Cancellation and Stake Refund Functionality

### 📌 Overview

This PR introduces two new functions to the PrediFi protocol:
- **`cancel_pool`** – Enables pool creators or admins to cancel pools when necessary.
- **`refund_stake`** – Ensures fair refunding of user stakes when a pool is canceled or deemed invalid.

These features enhance protocol integrity by enabling recovery from faulty or obsolete pool states while maintaining user trust.

---

### 🎯 Feature Summary

#### 🔒 `cancel_pool`
- Cancels a pool and updates its status to `Closed`.
- Callable **only** by the **pool creator** or an **admin**.
- Emits a `PoolCancelled` event with `pool_id` and `timestamp`.

#### 💸 `refund_stake`
- Refunds all users who staked in a canceled/closed pool.
- Ensures each user receives their full stake.
- Emits a `StakeRefunded` event per user.
- Reverts if:
  - The pool is not closed.
  - The user has no stake to refund.

---

### 🧪 Tests Added

#### ✅ **Pool Cancellation**
- `test_cancel_pool`: Confirms a pool can be successfully canceled by its creator.
- `test_cancel_pool_event_emission`: Asserts correct `PoolCancelled` event is emitted.
- `test_cancel_pool_by_unauthorized_caller`: Ensures unauthorized callers are rejected (`should_panic`).

#### ✅ **Stake Refund**
- `test_refund_stake_successful`: Verifies a staker is refunded correctly after pool cancellation.
- `test_refund_stake_event_emission`: Checks the correct `StakeRefunded` event is emitted.
- `test_refund_stake_on_open_pool`: Ensures refunding an open pool reverts with `Pool is not closed`.
- `test_refund_zero_stake`: Ensures refund fails if the user never staked (`Zero user stake`).

---

### 🛠️ Technical Highlights
- Enforced strict access control for `cancel_pool` using role verification.
- Safeguards in `refund_stake` to prevent double refunds or invalid refunds.
- Full use of cheat codes to simulate realistic contract interactions and state transitions.

---

### 📚 Documentation
- Updated function-level documentation to explain:
  - Who can call `cancel_pool` and `refund_stake`
  - Refund behavior and event structure
  - Failure conditions and edge case handling

---

### 🚀 Why This Matters
This update:
- Enhances **user safety** and platform **fairness**.
- Adds an important escape hatch for faulty pools.
- Strengthens the **trustless nature** of PrediFi.
- Ensures **transparent refunds** with proper event logs.

---

Closes #153
