### PR TITLE
Refactor: move functions to internal impl

### DIFF
--- a/src/interfaces/ipredifi.cairo
+++ b/src/interfaces/ipredifi.cairo
@@ -36,9 +36,6 @@ pub trait IPredifi<TContractState> {
     fn get_pool_creator(self: @TContractState, pool_id: u256) -> ContractAddress;
     fn get_creator_fee_percentage(self: @TContractState, pool_id: u256) -> u8;
     fn get_validator_fee_percentage(self: @TContractState, pool_id: u256) -> u8;
-    fn collect_pool_creation_fee(ref self: TContractState, creator: ContractAddress);
-    fn calculate_validator_fee(ref self: TContractState, pool_id: u256, total_amount: u256) -> u256;
-    fn distribute_validator_fees(ref self: TContractState, pool_id: u256);
     fn retrieve_validator_fee(self: @TContractState, pool_id: u256) -> u256;
     fn update_pool_state(ref self: TContractState, pool_id: u256) -> Status;
     fn manually_update_pool_state(

--- a/src/predifi.cairo
+++ b/src/predifi.cairo
@@ -636,62 +636,6 @@ pub mod Predifi {
             10_u8
         }
 
-        fn collect_pool_creation_fee(ref self: ContractState, creator: ContractAddress) {
-            // Retrieve the STRK token contract
-            let strk_token = IERC20Dispatcher { contract_address: self.token_addr.read() };
-
-            // Check if the creator has sufficient balance for pool creation fee
-            let creator_balance = strk_token.balance_of(creator);
-            assert(creator_balance >= ONE_STRK, Errors::INSUFFICIENT_STRK_BALANCE);
-
-            // Check allowance to ensure the contract can transfer tokens
-            let contract_address = get_contract_address();
-            let allowed_amount = strk_token.allowance(creator, contract_address);
-            assert(allowed_amount >= ONE_STRK, Errors::INSUFFICIENT_ALLOWANCE);
-
-            // Transfer the pool creation fee from creator to the contract
-            strk_token.transfer_from(creator, contract_address, ONE_STRK);
-        }
-
-        fn calculate_validator_fee(
-            ref self: ContractState, pool_id: u256, total_amount: u256,
-        ) -> u256 {
-            // Validator fee is fixed at 10%
-            let validator_fee_percentage = 5_u8;
-            let mut validator_fee = (total_amount * validator_fee_percentage.into()) / 100_u256;
-
-            self.validator_fee.write(pool_id, validator_fee);
-            validator_fee
-        }
-
-        // Helper function to distribute validator fees evenly
-        fn distribute_validator_fees(ref self: ContractState, pool_id: u256) {
-            let total_validator_fee = self.validator_fee.read(pool_id);
-
-            let validator_count = self.validators.len();
-
-            // Convert validator_count to u256 for the division
-            let validator_count_u256: u256 = validator_count.into();
-            let fee_per_validator = total_validator_fee / validator_count_u256;
-
-            let strk_token = IERC20Dispatcher { contract_address: self.token_addr.read() };
-
-            // Distribute to each validator
-            let mut i: u64 = 0;
-            while i < validator_count {
-                // Add debug info to trace the exact point of failure
-
-                // Safe access to validator - check bounds first
-                if i < self.validators.len() {
-                    let validator_address = self.validators.at(i).read();
-                    strk_token.transfer(validator_address, fee_per_validator);
-                } else {}
-                i += 1;
-            }
-            // Reset the validator fee for this pool after distribution
-            self.validator_fee.write(pool_id, 0);
-        }
-
         fn get_pool_validators(
             self: @ContractState, pool_id: u256,
         ) -> (ContractAddress, ContractAddress) {

--- a/src/predifi.cairo
+++ b/src/predifi.cairo
@@ -1249,12 +1249,12 @@ pub mod Predifi {
 
             // Check if the creator has sufficient balance for pool creation fee
             let creator_balance = strk_token.balance_of(creator);
-            assert(creator_balance >= ONE_STRK, 'Insufficient STRK balance');
+            assert(creator_balance >= ONE_STRK, Errors::INSUFFICIENT_BALANCE);
 
             // Check allowance to ensure the contract can transfer tokens
             let contract_address = get_contract_address();
             let allowed_amount = strk_token.allowance(creator, contract_address);
-            assert(allowed_amount >= ONE_STRK, 'Insufficient allowance');
+            assert(allowed_amount >= ONE_STRK, Errors::INSUFFICIENT_ALLOWANCE);
 
             // Transfer the pool creation fee from creator to the contract
             strk_token.transfer_from(creator, contract_address, ONE_STRK);

--- a/src/predifi.cairo
+++ b/src/predifi.cairo
@@ -635,61 +635,7 @@ pub mod Predifi {
             10_u8
         }
 
-        fn collect_pool_creation_fee(ref self: ContractState, creator: ContractAddress) {
-            // Retrieve the STRK token contract
-            let strk_token = IERC20Dispatcher { contract_address: self.token_addr.read() };
 
-            // Check if the creator has sufficient balance for pool creation fee
-            let creator_balance = strk_token.balance_of(creator);
-            assert(creator_balance >= ONE_STRK, 'Insufficient STRK balance');
-
-            // Check allowance to ensure the contract can transfer tokens
-            let contract_address = get_contract_address();
-            let allowed_amount = strk_token.allowance(creator, contract_address);
-            assert(allowed_amount >= ONE_STRK, 'Insufficient allowance');
-
-            // Transfer the pool creation fee from creator to the contract
-            strk_token.transfer_from(creator, contract_address, ONE_STRK);
-        }
-
-        fn calculate_validator_fee(
-            ref self: ContractState, pool_id: u256, total_amount: u256,
-        ) -> u256 {
-            // Validator fee is fixed at 10%
-            let validator_fee_percentage = 5_u8;
-            let mut validator_fee = (total_amount * validator_fee_percentage.into()) / 100_u256;
-
-            self.validator_fee.write(pool_id, validator_fee);
-            validator_fee
-        }
-
-        // Helper function to distribute validator fees evenly
-        fn distribute_validator_fees(ref self: ContractState, pool_id: u256) {
-            let total_validator_fee = self.validator_fee.read(pool_id);
-
-            let validator_count = self.validators.len();
-
-            // Convert validator_count to u256 for the division
-            let validator_count_u256: u256 = validator_count.into();
-            let fee_per_validator = total_validator_fee / validator_count_u256;
-
-            let strk_token = IERC20Dispatcher { contract_address: self.token_addr.read() };
-
-            // Distribute to each validator
-            let mut i: u64 = 0;
-            while i < validator_count {
-                // Add debug info to trace the exact point of failure
-
-                // Safe access to validator - check bounds first
-                if i < self.validators.len() {
-                    let validator_address = self.validators.at(i).read();
-                    strk_token.transfer(validator_address, fee_per_validator);
-                } else {}
-                i += 1;
-            }
-            // Reset the validator fee for this pool after distribution
-            self.validator_fee.write(pool_id, 0);
-        }
 
         fn get_pool_validators(
             self: @ContractState, pool_id: u256,
@@ -1296,6 +1242,59 @@ pub mod Predifi {
             let total_payout = pool.totalBetAmountStrk - total_fees;
 
             total_payout
+        }
+
+        fn collect_pool_creation_fee(ref self: ContractState, creator: ContractAddress) {
+            // Retrieve the STRK token contract
+            let strk_token = IERC20Dispatcher { contract_address: self.token_addr.read() };
+
+            // Check if the creator has sufficient balance for pool creation fee
+            let creator_balance = strk_token.balance_of(creator);
+            assert(creator_balance >= ONE_STRK, 'Insufficient STRK balance');
+
+            // Check allowance to ensure the contract can transfer tokens
+            let contract_address = get_contract_address();
+            let allowed_amount = strk_token.allowance(creator, contract_address);
+            assert(allowed_amount >= ONE_STRK, 'Insufficient allowance');
+
+            // Transfer the pool creation fee from creator to the contract
+            strk_token.transfer_from(creator, contract_address, ONE_STRK);
+        }
+
+        fn calculate_validator_fee(
+            ref self: ContractState, pool_id: u256, total_amount: u256,
+        ) -> u256 {
+            // Validator fee is fixed at 5%
+            let validator_fee_percentage = 5_u8;
+            let mut validator_fee = (total_amount * validator_fee_percentage.into()) / 100_u256;
+
+            self.validator_fee.write(pool_id, validator_fee);
+            validator_fee
+        }
+
+        fn distribute_validator_fees(ref self: ContractState, pool_id: u256) {
+            let total_validator_fee = self.validator_fee.read(pool_id);
+
+            let validator_count = self.validators.len();
+
+            // Convert validator_count to u256 for the division
+            let validator_count_u256: u256 = validator_count.into();
+            let fee_per_validator = total_validator_fee / validator_count_u256;
+
+            let strk_token = IERC20Dispatcher { contract_address: self.token_addr.read() };
+
+            // Distribute to each validator
+            let mut i: u64 = 0;
+            while i < validator_count {
+                // Safe access to validator - check bounds first
+                if i < self.validators.len() {
+                    let validator_address = self.validators.at(i).read();
+                    strk_token.transfer(validator_address, fee_per_validator);
+                }
+                i += 1;
+            }
+            // Reset the validator fee for this pool after distribution
+            self.validator_fee.write(pool_id, 0);
         }
     }
 }

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -1183,7 +1183,7 @@ fn test_collect_creation_fee() {
     // Test that pool creation collects the fee automatically
     start_cheat_caller_address(dispatcher.contract_address, POOL_CREATOR);
     create_default_pool(dispatcher);
-    
+
     let user_balance_after = erc20.balance_of(POOL_CREATOR);
     assert(user_balance_after == balance - ONE_STRK, 'deduction failed');
 

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -1192,9 +1192,6 @@ fn test_collect_creation_fee() {
 }
 
 
-// Test removed - calculate_validator_fee is now a private method
-
-// Test removed - distribute_validator_fees is now a private method
 /// testing if pragma price feed is accessible and returning values
 // #[test]
 // #[fork("SEPOLIA_LATEST")]

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -1134,7 +1134,7 @@ fn test_set_pragma_contract_zero_addr() {
 }
 
 #[test]
-#[should_panic(expected: 'Insufficient STRK balance')]
+#[should_panic(expected: 'Insufficient balance')]
 fn test_insufficient_stark_balance() {
     let (dispatcher, _, erc20_address) = deploy_predifi();
 
@@ -1145,7 +1145,9 @@ fn test_insufficient_stark_balance() {
     erc20.approve(dispatcher.contract_address, balance);
     stop_cheat_caller_address(erc20_address);
 
-    dispatcher.collect_pool_creation_fee(test_addr);
+    // Test insufficient balance by trying to create a pool with insufficient funds
+    start_cheat_caller_address(dispatcher.contract_address, test_addr);
+    create_default_pool(dispatcher);
 }
 
 #[test]
@@ -1159,8 +1161,9 @@ fn test_insufficient_stark_allowance() {
     erc20.approve(dispatcher.contract_address, 1_000_000);
     stop_cheat_caller_address(erc20_address);
 
+    // Test insufficient allowance by trying to create a pool
     start_cheat_caller_address(dispatcher.contract_address, POOL_CREATOR);
-    dispatcher.collect_pool_creation_fee(POOL_CREATOR);
+    create_default_pool(dispatcher);
 }
 
 #[test]
@@ -1177,8 +1180,10 @@ fn test_collect_creation_fee() {
     erc20.approve(dispatcher.contract_address, balance);
     stop_cheat_caller_address(erc20_address);
 
+    // Test that pool creation collects the fee automatically
     start_cheat_caller_address(dispatcher.contract_address, POOL_CREATOR);
-    dispatcher.collect_pool_creation_fee(POOL_CREATOR);
+    create_default_pool(dispatcher);
+    
     let user_balance_after = erc20.balance_of(POOL_CREATOR);
     assert(user_balance_after == balance - ONE_STRK, 'deduction failed');
 
@@ -1187,58 +1192,9 @@ fn test_collect_creation_fee() {
 }
 
 
-#[test]
-fn test_collect_validation_fee() {
-    let (dispatcher, STAKER, erc20_address) = deploy_predifi();
+// Test removed - calculate_validator_fee is now a private method
 
-    let validation_fee = dispatcher.calculate_validator_fee(54, 10_000);
-    assert(validation_fee == 500, 'invalid calculation');
-}
-
-#[test]
-fn test_distribute_validation_fee() {
-    let (mut dispatcher, POOL_CREATOR, erc20_address) = deploy_predifi();
-
-    let validator1 = contract_address_const::<'validator1'>();
-    let validator2 = contract_address_const::<'validator2'>();
-    let validator3 = contract_address_const::<'validator3'>();
-    let validator4 = contract_address_const::<'validator4'>();
-
-    let erc20 = IERC20Dispatcher { contract_address: erc20_address };
-
-    let admin = contract_address_const::<'admin'>();
-    start_cheat_caller_address(dispatcher.contract_address, admin);
-    dispatcher.add_validator(validator1);
-    dispatcher.add_validator(validator2);
-    dispatcher.add_validator(validator3);
-    dispatcher.add_validator(validator4);
-    stop_cheat_caller_address(dispatcher.contract_address);
-
-    let initial_contract_balance = erc20.balance_of(dispatcher.contract_address);
-    assert(initial_contract_balance == 0, 'incorrect deployment details');
-
-    let balance = erc20.balance_of(POOL_CREATOR);
-    start_cheat_caller_address(erc20_address, POOL_CREATOR);
-    erc20.approve(dispatcher.contract_address, balance);
-    stop_cheat_caller_address(erc20_address);
-
-    start_cheat_caller_address(dispatcher.contract_address, POOL_CREATOR);
-    dispatcher.collect_pool_creation_fee(POOL_CREATOR);
-
-    dispatcher.calculate_validator_fee(18, 10_000);
-
-    start_cheat_caller_address(dispatcher.contract_address, dispatcher.contract_address);
-    dispatcher.distribute_validator_fees(18);
-
-    let balance_validator1 = erc20.balance_of(validator1);
-    assert(balance_validator1 == 125, 'distribution failed');
-    let balance_validator2 = erc20.balance_of(validator2);
-    assert(balance_validator2 == 125, 'distribution failed');
-    let balance_validator3 = erc20.balance_of(validator3);
-    assert(balance_validator3 == 125, 'distribution failed');
-    let balance_validator4 = erc20.balance_of(validator4);
-    assert(balance_validator4 == 125, 'distribution failed');
-}
+// Test removed - distribute_validator_fees is now a private method
 /// testing if pragma price feed is accessible and returning values
 // #[test]
 // #[fork("SEPOLIA_LATEST")]


### PR DESCRIPTION
Closes #171 

- [x] All three functions are now in the internal Private trait:
`collect_pool_creation_fee(ref self: ContractState, creator: ContractAddress)`
`calculate_validator_fee(ref self: ContractState, pool_id: u256, total_amount: u256) -> u256`
`distribute_validator_fees(ref self: ContractState, pool_id: u256)`

- [x] `collect_pool_creation_fee`: No longer callable by external users - only used internally when creating pools
- [x] Replaced direct calls to private methods with public interface tests