### PR TITLE
feat: u8_to_enum utility functions

### DIFF
--- a/src/base/types.cairo
+++ b/src/base/types.cairo
@@ -96,6 +96,46 @@ pub fn u8_to_pool(pool_type: u8) -> Pool {
     }
 }
 
+/// @notice Converts a u8 to a ValidateOptions enum.
+/// @param validate_option The validate option as u8.
+/// @return The ValidateOptions enum value.
+pub fn u8_to_validate_option(validate_option: u8) -> ValidateOptions {
+    match validate_option {
+        0 => ValidateOptions::Win,
+        1 => ValidateOptions::Loss,
+        2 => ValidateOptions::Void,
+        _ => panic!("Invalid validate option: must be 0-2"),
+    }
+}
+
+/// @notice Converts a u8 to a Category enum.
+/// @param category The category type as u8.
+/// @return The Category enum value.
+pub fn u8_to_category(category: u8) -> Category {
+    match category {
+        0 => Category::Sports,
+        1 => Category::Politics,
+        2 => Category::Entertainment,
+        3 => Category::Crypto,
+        4 => Category::Other,
+        _ => panic!("Invalid category: must be 0-4"),
+    }
+}
+
+/// @notice Converts a u8 to a Status enum.
+/// @param status The status type as u8.
+/// @return The Status enum value.
+pub fn u8_to_status(status: u8) -> Status {
+    match status {
+        0 => Status::Active,
+        1 => Status::Locked,
+        2 => Status::Settled,
+        3 => Status::Closed,
+        4 => Status::Suspended,
+        _ => panic!("Invalid status: must be 0-4"),
+    }
+}
+
 /// @notice Enum representing the category of a pool.
 #[derive(Copy, Drop, Serde, PartialEq, Debug, starknet::Store)]
 pub enum Category {

--- a/src/interfaces/ipredifi.cairo
+++ b/src/interfaces/ipredifi.cairo
@@ -1,5 +1,5 @@
 use starknet::{ClassHash, ContractAddress};
-use crate::base::types::{Category, PoolDetails, PoolOdds, Status, UserStake};
+use crate::base::types::{PoolDetails, PoolOdds, Status, UserStake};
 
 #[starknet::interface]
 pub trait IPredifi<TContractState> {
@@ -39,7 +39,7 @@ pub trait IPredifi<TContractState> {
         maxBetAmount: u256,
         creatorFee: u8,
         isPrivate: bool,
-        category: Category,
+        category: u8,
     ) -> u256;
 
     /// @notice Cancels a pool. Only the pool creator can cancel.
@@ -125,7 +125,7 @@ pub trait IPredifi<TContractState> {
     /// @param new_status The new status to set.
     /// @return The updated status.
     fn manually_update_pool_state(
-        ref self: TContractState, pool_id: u256, new_status: Status,
+        ref self: TContractState, pool_id: u256, new_status: u8,
     ) -> Status;
 
     /// @notice Returns the number of pools a user has participated in.


### PR DESCRIPTION
# 📄 Description

This PR introduces utility functions for converting `u8` values to their corresponding enums, refactors contract interfaces for cleaner usage, updates related tests, and replaces deprecated Cairo features to maintain compatibility.

Fixes #198

---

# 🛠 Changes Made

## ✨ Enum Conversion Utilities
Added the following helper functions to improve type handling and input clarity:
- `u8_to_pool(u8) -> Pool`
- `u8_to_validate_option(u8) -> ValidateOptions`
- `u8_to_category(u8) -> Category`
- `u8_to_status(u8) -> Status`

These make it easier to map numeric inputs to enums, especially when receiving raw `u8` values externally.

---

## 🔁 Contract Refactors
- Updated contract functions to accept `u8` instead of enum variants directly.
- Used the new utility functions internally to convert `u8` to the correct enum.

---

## 🧪 Tests Updated
- Adjusted all affected tests to pass `u8` values.
- Ensured compatibility and correctness of contract behavior after the refactor.

---

## 🧹 Cairo Syntax Cleanup
- Removed usage of deprecated features such as `contract_address_const`.
- Replaced them with up-to-date Cairo patterns.
- Updated related tests to match the new structure.

---

# ✅ Why It Matters
- Centralizes and simplifies enum conversion logic
- Improves contract interface usability (especially for frontend or SDK integration)
- Prevents potential issues from deprecated Cairo syntax
- Makes the codebase more maintainable and scalable

---

# ⚠️ Notes
- This is a **breaking change** to how enums are passed in.
- Ensure any frontend or SDK calling these contracts is updated to use `u8` values.