### PR TITLE
feat: Support for More Than 10 Outcome Options (#321)

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -432,7 +432,9 @@ impl PredifiContract {
 
         // Also update individual key for backward compatibility
         let outcome_key = DataKey::OutcomeStake(pool_id, outcome);
-        env.storage().persistent().set(&outcome_key, &(current + amount));
+        env.storage()
+            .persistent()
+            .set(&outcome_key, &(current + amount));
         Self::extend_persistent(env, &outcome_key);
 
         stakes
@@ -937,13 +939,8 @@ impl PredifiContract {
         Self::extend_persistent(&env, &pool_key);
 
         // Update outcome stake (INV-1) - using optimized batch storage
-        let _stakes = Self::update_outcome_stake(
-            &env,
-            pool_id,
-            outcome,
-            amount,
-            pool.options_count,
-        );
+        let _stakes =
+            Self::update_outcome_stake(&env, pool_id, outcome, amount, pool.options_count);
 
         let count_key = DataKey::UserPredictionCount(user.clone());
         let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);


### PR DESCRIPTION
Closes #321

---

## Summary

Implement support for prediction markets with high numbers of outcomes (e.g., 32-team tournament brackets).

## Changes

### 1. New Storage Key
- Added `OutcomeStakes(u64)` to `DataKey` enum for batch storage of all outcome stakes as a single `Vec<i128>`

### 2. New Event
- Added `OutcomeStakesUpdatedEvent` for markets with 16+ outcomes to avoid emitting individual events per outcome

### 3. Helper Functions
- Added `get_outcome_stakes()` - Retrieve batch stakes with backward compatibility
- Added `update_outcome_stake()` - Update stakes using optimized batch storage

### 4. Updated Functions & New Query APIs
- Updated `place_prediction()` to use batch storage
- Updated `resolve_pool()` to use batch storage  
- Updated `claim_winnings()` to use batch storage
- Added public `get_pool_outcome_stakes()` for batch query
- Added public `get_outcome_stake()` for backward-compatible single query

## Optimization Benefits
- Reduces storage reads from O(N) to O(1) for markets with many outcomes
- Maintains backward compatibility with existing individual outcome stake keys
- Significantly reduces gas costs for large tournament-style prediction markets

## Commits
- feat: add OutcomeStakes batch storage key for high-outcome markets
- feat: add OutcomeStakesUpdatedEvent for large outcome sets
- feat: add optimized outcome stake tracking helper functions
- feat: update existing functions to use batch storage and add query APIs

Refs: #321