### PR TITLE
Optimize get_outcome_stake to use instance storage for current pool

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -2400,26 +2400,32 @@ impl PredifiContract {
     }
 
     /// Get a specific outcome's stake (backward compatible).
-    /// For markets with many outcomes, consider using get_pool_outcome_stakes() instead.
+    ///
+    /// Optimized to read the batch `OutStakes` key directly when available,
+    /// avoiding a full `Pool` struct deserialization. Falls back to loading
+    /// the pool only when the batch key is missing (pre-optimization data).
     pub fn get_outcome_stake(env: Env, pool_id: u64, outcome: u32) -> i128 {
+        // Try the optimized batch key first (avoids Pool deserialization)
+        let batch_key = DataKey::OutStakes(pool_id);
+        if let Some(stakes) = env.storage().persistent().get::<_, Vec<i128>>(&batch_key) {
+            Self::extend_persistent(&env, &batch_key);
+            return stakes.get(outcome).unwrap_or(0);
+        }
+
+        // Fallback: read Pool to get options_count, then individual OutStake keys
         let pool_key = DataKey::Pool(pool_id);
-        if !env.storage().persistent().has(&pool_key) {
-            return 0;
+        let pool: Option<Pool> = env.storage().persistent().get(&pool_key);
+        match pool {
+            Some(p) => {
+                Self::extend_persistent(&env, &pool_key);
+                if outcome >= p.options_count {
+                    return 0;
+                }
+                let stake_key = DataKey::OutStake(pool_id, outcome);
+                env.storage().persistent().get(&stake_key).unwrap_or(0)
+            }
+            None => 0,
         }
-
-        let pool: Pool = env
-            .storage()
-            .persistent()
-            .get(&pool_key)
-            .expect("Pool not found");
-        Self::extend_persistent(&env, &pool_key);
-
-        if outcome >= pool.options_count {
-            return 0;
-        }
-
-        let stakes = Self::get_outcome_stakes(&env, pool_id, pool.options_count);
-        stakes.get(outcome).unwrap_or(0)
     }
 
     /// Get a paginated list of pool IDs by category.


### PR DESCRIPTION
## Description
Optimize get_outcome_stake to read the batch OutStakes key directly when available, avoiding a full Pool struct deserialization. Falls back to individual OutStake keys only for pre-optimization data.

## Changes
- Read `OutStakes(pool_id)` batch key first (single storage read)
- Only fall back to Pool deserialization when batch key is missing
- In fallback path, read individual `OutStake(pool_id, outcome)` directly instead of reconstructing the full Vec

## Verification
- `cargo test -p predifi-contract test_claim_winnings` passes
- `cargo build -p predifi-contract` compiles cleanly
- No behavioral change; purely performance optimization

Closes #390