### PR TITLE
feat: implement dynamic fee tiers based on pool volume

### DIFF
--- a/contract/contracts/predifi-contract/src/fee_tiers_test.rs
+++ b/contract/contracts/predifi-contract/src/fee_tiers_test.rs
@@ -1,0 +1,180 @@
+#![cfg(test)]
+
+use crate::test::ROLE_ADMIN;
+use crate::{FeeTier, PoolConfig};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    vec, Address, Env, String, Vec,
+};
+
+#[test]
+fn test_dynamic_fee_tiers_application() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (
+        ac_client,
+        client,
+        token_address,
+        _token,
+        token_admin_client,
+        _treasury,
+        operator,
+        creator,
+    ) = crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    // Set global fee to 3%
+    client.set_fee_bps(&admin, &300u32);
+
+    // Set up fee tiers
+    // Threshold 1M (1,000,000 * 10^7) -> 1% (100 bps)
+    // Threshold 5M (5,000,000 * 10^7) -> 0.5% (50 bps)
+    let tiers = Vec::from_array(
+        &env,
+        [
+            FeeTier {
+                stake_threshold: 1_000_000 * 10_000_000,
+                fee_bps: 100,
+            },
+            FeeTier {
+                stake_threshold: 5_000_000 * 10_000_000,
+                fee_bps: 50,
+            },
+        ],
+    );
+
+    client.set_fee_tiers(&admin, &tiers);
+
+    // 1. Create a pool with low volume (below 1M)
+    let end_time_1 = env.ledger().timestamp() + 10000;
+    let pool_id = client.create_pool(
+        &creator,
+        &end_time_1,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Low Volume Pool"),
+            metadata_url: String::from_str(&env, "ipfs://test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: vec![
+                &env,
+                String::from_str(&env, "A"),
+                String::from_str(&env, "B"),
+            ],
+        },
+    );
+
+    // Resolve it
+    env.ledger().set_timestamp(end_time_1 + 1000);
+    client.resolve_pool(&operator, &pool_id, &0);
+
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.fee_bps, 300); // Should use global default (300)
+
+    // 2. Create a pool with medium volume (2M)
+    let end_time_2 = env.ledger().timestamp() + 10000;
+    let pool_id_2 = client.create_pool(
+        &creator,
+        &end_time_2,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Med Volume Pool"),
+            metadata_url: String::from_str(&env, "ipfs://test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: vec![
+                &env,
+                String::from_str(&env, "A"),
+                String::from_str(&env, "B"),
+            ],
+        },
+    );
+
+    let user = Address::generate(&env);
+    token_admin_client.mint(&user, &(2_000_000 * 10_000_000));
+    client.place_prediction(
+        &user,
+        &pool_id_2,
+        &(2_000_000 * 10_000_000),
+        &0,
+        &None,
+        &None,
+    );
+
+    env.ledger().set_timestamp(end_time_2 + 1000);
+    client.resolve_pool(&operator, &pool_id_2, &0);
+
+    let pool2 = client.get_pool(&pool_id_2);
+    assert_eq!(pool2.fee_bps, 100); // Should apply 1% tier
+
+    // 3. Create a pool with high volume (6M)
+    let end_time_3 = env.ledger().timestamp() + 10000;
+    let pool_id_3 = client.create_pool(
+        &creator,
+        &end_time_3,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "High Volume Pool"),
+            metadata_url: String::from_str(&env, "ipfs://test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: vec![
+                &env,
+                String::from_str(&env, "A"),
+                String::from_str(&env, "B"),
+            ],
+        },
+    );
+    token_admin_client.mint(&user, &(6_000_000 * 10_000_000));
+    client.place_prediction(
+        &user,
+        &pool_id_3,
+        &(6_000_000 * 10_000_000),
+        &0,
+        &None,
+        &None,
+    );
+
+    env.ledger().set_timestamp(end_time_3 + 1000);
+    client.resolve_pool(&operator, &pool_id_3, &0);
+
+    let pool3 = client.get_pool(&pool_id_3);
+    assert_eq!(pool3.fee_bps, 50); // Should apply 0.5% tier
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_set_fee_tiers_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client, _, _, _, _, _, _) = crate::test::setup(&env);
+    let user = Address::generate(&env);
+    let tiers = Vec::new(&env);
+
+    client.set_fee_tiers(&user, &tiers);
+}

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -171,6 +171,10 @@ pub enum PredifiError {
     StakeBelowMinimum = 107,
     /// Stake amount exceeds the pool maximum.
     StakeAboveMaximum = 108,
+    /// The fee basis points exceed the maximum allowed value (10000).
+    InvalidFeeBps = 93,
+    /// An arithmetic overflow, underflow, or division by zero occurred.
+    ArithmeticError = 110,
 }
 
 /// Represents the current state of a prediction market.
@@ -274,6 +278,7 @@ pub struct Pool {
     pub whitelist_key: Option<Symbol>,
     /// Human-readable labels for each outcome (length must equal options_count).
     pub outcome_descriptions: Vec<String>,
+    pub fee_bps: u32,
 }
 
 /// Configuration parameters for creating a prediction pool.
@@ -348,6 +353,19 @@ pub struct Config {
     pub resolution_delay: u64,
     /// Minimum pool duration in seconds.
     pub min_pool_duration: u64,
+}
+
+/// Represents a single tier in the dynamic fee system.
+///
+/// Tiers are applied based on the total stake (volume) of the pool at resolution time.
+/// Higher volumes typically result in lower fee percentages to encourage participation.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeTier {
+    /// The total stake threshold at or above which this tier applies.
+    pub stake_threshold: i128,
+    /// The fee in basis points to apply for this tier (0-10,000).
+    pub fee_bps: u32,
 }
 
 /// Detailed information about a user's prediction in a specific pool.
@@ -438,6 +456,7 @@ pub enum DataKey {
     PriceCondition(u64),
     /// Latest price feed data: PriceFeed(feed_pair) -> (price, confidence, timestamp, expires_at)
     PriceFeed(Symbol),
+    FeeTiers,
 }
 
 /// Represents a user's prediction in a pool.
@@ -482,6 +501,13 @@ pub struct UnpauseEvent {
 pub struct FeeUpdateEvent {
     pub admin: Address,
     pub fee_bps: u32,
+}
+
+#[contractevent(topics = ["fee_tiers_update"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeTiersUpdateEvent {
+    pub admin: Address,
+    pub tiers_count: u32,
 }
 
 #[contractevent(topics = ["treasury_update"])]
@@ -1518,6 +1544,7 @@ impl PredifiContract {
             private: config.private,
             whitelist_key: config.whitelist_key.clone(),
             outcome_descriptions: config.outcome_descriptions.clone(),
+            fee_bps: 0, // Will be set at resolution
         };
 
         let pool_key = DataKey::Pool(pool_id);
@@ -1745,6 +1772,7 @@ impl PredifiContract {
             pool.state = MarketState::Resolved;
             pool.resolved = true;
             pool.outcome = outcome;
+            pool.fee_bps = Self::calculate_dynamic_fee(&env, &pool);
 
             env.storage().persistent().set(&pool_key, &pool);
             Self::bump_ttl(&env, &pool_key);
@@ -2147,9 +2175,14 @@ impl PredifiContract {
                 return Ok(0);
             }
 
-            // Protocol fee: deducted from pool before distribution (flat fee_bps, no dependency on 317)
-            let config = Self::get_config(&env);
-            let fee_bps_i = config.fee_bps as i128;
+            // Protocol fee: deducted from pool before distribution
+            // Use pool-specific fee (calculated at resolution) if available, else fallback to global
+            let fee_bps_i = if pool.fee_bps > 0 || pool.state == MarketState::Resolved {
+                pool.fee_bps as i128
+            } else {
+                let config = Self::get_config(&env);
+                config.fee_bps as i128
+            };
             let protocol_fee_total =
                 SafeMath::percentage(pool.total_stake, fee_bps_i, RoundingMode::ProtocolFavor)
                     .map_err(|_| PredifiError::InvalidAmount)?;
@@ -2762,6 +2795,7 @@ impl PredifiContract {
         pool.state = MarketState::Resolved;
         pool.resolved = true;
         pool.outcome = outcome;
+        pool.fee_bps = Self::calculate_dynamic_fee(&env, &pool);
 
         env.storage().persistent().set(&pool_key, &pool);
         Self::bump_ttl(&env, &pool_key);
@@ -2774,6 +2808,59 @@ impl PredifiContract {
         .publish(&env);
 
         Ok(())
+    }
+    pub fn set_fee_tiers(
+        env: Env,
+        admin: Address,
+        tiers: Vec<FeeTier>,
+    ) -> Result<(), PredifiError> {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+        Self::require_admin_role(&env, &admin, "set_fee_tiers")?;
+
+        for i in 0..tiers.len() {
+            if let Some(tier) = tiers.get(i) {
+                if tier.fee_bps > 10_000 {
+                    return Err(PredifiError::InvalidFeeBps);
+                }
+            }
+        }
+
+        env.storage().persistent().set(&DataKey::FeeTiers, &tiers);
+        Self::bump_ttl(&env, &DataKey::FeeTiers);
+
+        FeeTiersUpdateEvent {
+            admin,
+            tiers_count: tiers.len(),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_fee_tiers(env: Env) -> Vec<FeeTier> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::FeeTiers)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    fn calculate_dynamic_fee(env: &Env, pool: &Pool) -> u32 {
+        let config = Self::get_config(env);
+        let tiers = Self::get_fee_tiers(env.clone());
+        let mut applied_fee = config.fee_bps;
+
+        let mut max_threshold = -1i128;
+        for i in 0..tiers.len() {
+            if let Some(tier) = tiers.get(i) {
+                if pool.total_stake >= tier.stake_threshold && tier.stake_threshold > max_threshold
+                {
+                    max_threshold = tier.stake_threshold;
+                    applied_fee = tier.fee_bps;
+                }
+            }
+        }
+        applied_fee
     }
 }
 
@@ -2887,6 +2974,7 @@ impl OracleCallback for PredifiContract {
             pool.state = MarketState::Resolved;
             pool.resolved = true;
             pool.outcome = outcome;
+            pool.fee_bps = Self::calculate_dynamic_fee(&env, &pool);
 
             env.storage().persistent().set(&pool_key, &pool);
             Self::bump_ttl(&env, &pool_key);
@@ -2917,5 +3005,6 @@ impl OracleCallback for PredifiContract {
     }
 }
 
+mod fee_tiers_test;
 mod integration_test;
 mod test;

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -13,7 +13,7 @@ use soroban_sdk::{
     token, vec, Address, BytesN, Env, IntoVal, String, Symbol, TryFromVal, Val,
 };
 
-mod dummy_access_control {
+pub(crate) mod dummy_access_control {
     use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
 
     #[contract]
@@ -61,11 +61,11 @@ mod rogue_token {
     }
 }
 
-const ROLE_ADMIN: u32 = 0; // i am testing this
-const ROLE_OPERATOR: u32 = 1; // i am testing this the second one
+pub(crate) const ROLE_ADMIN: u32 = 0; // i am testing this
+pub(crate) const ROLE_OPERATOR: u32 = 1; // i am testing this the second one
 const ROLE_ORACLE: u32 = 3;
 
-fn setup(
+pub(crate) fn setup(
     env: &Env,
 ) -> (
     dummy_access_control::DummyAccessControlClient<'_>,


### PR DESCRIPTION
# Dynamic Fee Tiers Based on Volume
**Branch**: `feature/dynamic-fee-tiers`
**Issue Reference**: #317
### Description
This PR implements a dynamic protocol fee system where the fee percentage applied to a pool is determined by its total volume (total stake) at the point of resolution. This incentivizes higher participation by offering lower fee tiers for high-volume markets.
### Key Changes
- **Data Models**:
    - Added [FeeTier](cci:2://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:363:0-368:1) struct to define `stake_threshold` and [fee_bps](cci:1://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:1176:4-1191:5).
    - Updated [Pool](cci:2://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:238:0-281:1) struct to store the resulting [fee_bps](cci:1://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:1176:4-1191:5) determined at resolution time.
    - Added `DataKey::FeeTiers` for persistent configuration storage.
- **Dynamic Resolution Logic**:
    - Updated [resolve_pool](cci:1://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:1672:4-1801:5), [resolve_pool_from_price](cci:1://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:2737:4-2810:5), and [oracle_resolve](cci:1://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:2868:4-3004:5) to calculate and store the applicable fee tier.
    - Added internal helper [calculate_dynamic_fee](cci:1://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:2847:4-2863:5) to find the highest threshold tier satisfied by the pool volume.
- **Admin Functions**:
    - [set_fee_tiers](cci:1://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:2811:4-2838:5): Allows governance to update the fee schedule.
    - [get_fee_tiers](cci:1://file:///home/edohwares/Desktop/Room/drips/predifi/contract/contracts/predifi-contract/src/lib.rs:2840:4-2845:5): Public view function to check active tiers.


Closes #317 