### PR TITLE
feat(contract): add set_min_stake and global minimum stake enforcement

### DIFF
--- a/contract/contracts/predifi-contract/src/constants.rs
+++ b/contract/contracts/predifi-contract/src/constants.rs
@@ -27,6 +27,10 @@ pub const BUMP_AMOUNT: u32 = 30 * DAY_IN_LEDGERS;
 /// Pools must be active for at least this duration before they can end.
 pub const DEFAULT_MIN_POOL_DURATION: u64 = 3600;
 
+/// Default global minimum stake amount (1 unit in base token units).
+/// Predictions below this threshold are rejected to prevent spam.
+pub const DEFAULT_GLOBAL_MIN_STAKE: i128 = 1;
+
 /// Maximum number of options/outcomes allowed in a single pool.
 /// This limit prevents excessive gas costs and ensures reasonable pool complexity.
 pub const MAX_OPTIONS_COUNT: u32 = 100;

--- a/contract/contracts/predifi-contract/src/events.rs
+++ b/contract/contracts/predifi-contract/src/events.rs
@@ -59,6 +59,13 @@ pub struct MinPoolDurationUpdateEvent {
     pub duration: u64,
 }
 
+#[contractevent(topics = ["min_stake_update"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MinStakeUpdateEvent {
+    pub admin: Address,
+    pub min_stake: i128,
+}
+
 #[contractevent(topics = ["pool_ready"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PoolReadyForResolutionEvent {

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -158,6 +158,8 @@ pub enum PredifiError {
     StakeBelowMinimum = 107,
     /// Stake amount exceeds the pool maximum.
     StakeAboveMaximum = 108,
+    /// Stake amount is below the global protocol minimum.
+    InsufficientStake = 45,
     /// The fee basis points exceed the maximum allowed value (10000).
     InvalidFeeBps = 93,
     /// Metadata URL exceeds maximum length (512 bytes).
@@ -349,6 +351,8 @@ pub struct Config {
     pub resolution_delay: u64,
     /// Minimum pool duration in seconds.
     pub min_pool_duration: u64,
+    /// Global minimum stake amount. Predictions below this are rejected.
+    pub min_stake: i128,
 }
 
 /// Fee percentages returned by [`PredifiContract::get_fees`].
@@ -572,6 +576,13 @@ pub struct ResolutionDelayUpdateEvent {
 pub struct MinPoolDurationUpdateEvent {
     pub admin: Address,
     pub duration: u64,
+}
+
+#[contractevent(topics = ["min_stake_update"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MinStakeUpdateEvent {
+    pub admin: Address,
+    pub min_stake: i128,
 }
 
 #[contractevent(topics = ["pool_ready"])]
@@ -1249,6 +1260,7 @@ impl PredifiContract {
                 access_control: access_control.clone(),
                 resolution_delay,
                 min_pool_duration,
+                min_stake: DEFAULT_GLOBAL_MIN_STAKE,
             };
             env.storage().instance().set(&DataKey::Config, &config);
             env.storage().instance().set(&DataKey::PoolIdCtr, &0u64);
@@ -1398,6 +1410,33 @@ impl PredifiContract {
         Self::extend_instance(&env);
 
         MinPoolDurationUpdateEvent { admin, duration }.publish(&env);
+        Ok(())
+    }
+
+    /// Set the global minimum stake amount. Caller must have Admin role (0).
+    ///
+    /// Predictions with an amount below this threshold will be rejected with
+    /// `PredifiError::InsufficientStake`. This prevents spam from micro-predictions.
+    ///
+    /// # Arguments
+    /// * `admin`  - Address with Admin role (0).
+    /// * `amount` - New minimum stake in base token units. Must be > 0.
+    pub fn set_min_stake(env: Env, admin: Address, amount: i128) -> Result<(), PredifiError> {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+        Self::require_admin_role(&env, &admin, "set_min_stake")?;
+        assert!(amount > 0, "min_stake must be greater than zero");
+
+        let mut config = Self::get_config(&env);
+        config.min_stake = amount;
+        env.storage().instance().set(&DataKey::Config, &config);
+        Self::extend_instance(&env);
+
+        MinStakeUpdateEvent {
+            admin,
+            min_stake: amount,
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -2195,6 +2234,12 @@ impl PredifiContract {
         Self::require_not_paused(&env);
         user.require_auth();
         assert!(amount > 0, "amount must be positive");
+
+        // Validate: amount must meet the global protocol minimum stake
+        let global_min_stake = Self::get_config(&env).min_stake;
+        if amount < global_min_stake {
+            soroban_sdk::panic_with_error!(&env, PredifiError::InsufficientStake);
+        }
 
         // Validate referrer if provided: cannot be self or contract
         if let Some(ref r) = referrer {

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -8366,3 +8366,111 @@ fn test_create_pool_accepts_positive_min_total_stake() {
     let pool = client.get_pool(&pool_id);
     assert_eq!(pool.min_total_stake, 100i128);
 }
+
+// ── set_min_stake / InsufficientStake tests ──────────────────────────────────
+
+/// A prediction of 0.1 (amount=1 in 1-decimal units) must fail when the
+/// global minimum is 1.0 (amount=10 in 1-decimal units).
+/// Concretely: set min_stake=10, attempt place_prediction with amount=1.
+#[test]
+#[should_panic(expected = "Error(Contract, #45)")]
+fn test_place_prediction_below_global_min_stake_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, token_address, _, token_admin_client, _, _, creator) = setup(&env);
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let user = Address::generate(&env);
+    token_admin_client.mint(&user, &1_000_000i128);
+
+    // Set global min_stake to 10 (represents 1.0 at 1 decimal place)
+    client.set_min_stake(&admin, &10i128);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Min stake test pool"),
+            metadata_url: String::from_str(&env, "ipfs://min-stake-test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    // amount=1 is below global min_stake=10 → must panic with InsufficientStake (#45)
+    client.place_prediction(&user, &pool_id, &1i128, &0u32, &None, &None);
+}
+
+/// A prediction at or above the global min_stake must succeed.
+#[test]
+fn test_place_prediction_at_global_min_stake_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, token_address, _, token_admin_client, _, _, creator) = setup(&env);
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let user = Address::generate(&env);
+    token_admin_client.mint(&user, &1_000_000i128);
+
+    // Set global min_stake to 10
+    client.set_min_stake(&admin, &10i128);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Min stake pass test pool"),
+            metadata_url: String::from_str(&env, "ipfs://min-stake-pass"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    // amount=10 equals global min_stake=10 → must succeed (no panic)
+    client.place_prediction(&user, &pool_id, &10i128, &0u32, &None, &None);
+}
+
+/// set_min_stake must be rejected for non-admin callers.
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_set_min_stake_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, _, _, _, _, _, _) = setup(&env);
+    let non_admin = Address::generate(&env);
+
+    client.set_min_stake(&non_admin, &10i128);
+}


### PR DESCRIPTION
CLoses: #545 

- Add `DEFAULT_GLOBAL_MIN_STAKE = 1` constant to `constants.rs`.
- Add `min_stake: i128` field to the `Config` struct in `lib.rs`; initialized to `DEFAULT_GLOBAL_MIN_STAKE` in `init`.
- Add `InsufficientStake = 45` variant to the local `PredifiError` enum.
- Add `MinStakeUpdateEvent` (topic: "min_stake_update") in both `lib.rs` and `events.rs`.
- Add `pub fn set_min_stake(env, admin, amount: i128)` admin function that validates `amount > 0`, updates `Config.min_stake`, and emits `MinStakeUpdateEvent`. Follows the same pattern as `set_fee_bps` / `set_min_pool_duration`.
- In `place_prediction`, add a global min-stake guard immediately after the `amount > 0` assertion: if `amount < config.min_stake` the call panics with `PredifiError::InsufficientStake` (#45).

Why it was needed (issue #545):
  Bots can spam the network with near-zero predictions, clogging the UI and inflating on-chain storage costs. A protocol-level minimum stake enforced in `place_prediction` prevents this without requiring per-pool configuration.

Tests added (test.rs):
- `test_place_prediction_below_global_min_stake_fails`: sets min_stake=10, attempts amount=1 → expects panic Error(Contract, #45).
- `test_place_prediction_at_global_min_stake_succeeds`: sets min_stake=10, places amount=10 → succeeds.
- `test_set_min_stake_unauthorized`: non-admin call → expects panic Error(Contract, #10).

Assumptions:
- The global min_stake is a floor; per-pool `min_stake` (on `PoolConfig`) remains a separate, pool-level constraint checked afterwards.
- Default of 1 base unit is intentionally minimal so existing deployments are unaffected until an admin explicitly raises the threshold.