### PR TITLE
feat(contract): add participants_count to Pool and expose get_pool_pa…

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -272,6 +272,8 @@ pub struct Pool {
     /// Human-readable labels for each outcome (length must equal options_count).
     pub outcome_descriptions: Vec<String>,
     pub fee_bps: u32,
+    /// Number of unique addresses that have placed at least one prediction in this pool.
+    pub participants_count: u32,
 }
 
 /// Configuration parameters for creating a prediction pool.
@@ -1745,6 +1747,7 @@ impl PredifiContract {
             whitelist_key: config.whitelist_key.clone(),
             outcome_descriptions: config.outcome_descriptions.clone(),
             fee_bps: 0, // Will be set at resolution
+            participants_count: 0,
         };
 
         let pool_key = DataKey::Pool(pool_id);
@@ -2317,6 +2320,10 @@ impl PredifiContract {
             let pc: u32 = env.storage().persistent().get(&pc_key).unwrap_or(0);
             env.storage().persistent().set(&pc_key, &(pc + 1));
             Self::extend_persistent(&env, &pc_key);
+
+            // Mirror the count on the Pool struct so get_pool_participants_count
+            // can read it with a single storage fetch.
+            pool.participants_count = pool.participants_count.saturating_add(1);
 
             let count_key = DataKey::UsrPrdCnt(user.clone());
             let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
@@ -2995,6 +3002,27 @@ impl PredifiContract {
             Self::extend_persistent(&env, &whitelist_key);
         }
         is_whitelisted
+    }
+
+    /// Return the number of unique participants in a pool.
+    ///
+    /// A participant is any address that has placed at least one prediction.
+    /// Subsequent top-ups by the same address do not increase the count.
+    ///
+    /// # Arguments
+    /// * `pool_id` - The unique identifier of the pool.
+    ///
+    /// # Returns
+    /// The number of unique participants as a `u32`.
+    pub fn get_pool_participants_count(env: Env, pool_id: u64) -> u32 {
+        let pool_key = DataKey::Pool(pool_id);
+        let pool: Pool = env
+            .storage()
+            .persistent()
+            .get(&pool_key)
+            .expect("Pool not found");
+        Self::extend_persistent(&env, &pool_key);
+        pool.participants_count
     }
 
     /// Get comprehensive stats for a pool.

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -8366,3 +8366,112 @@ fn test_create_pool_accepts_positive_min_total_stake() {
     let pool = client.get_pool(&pool_id);
     assert_eq!(pool.min_total_stake, 100i128);
 }
+
+// ── get_pool_participants_count tests ─────────────────────────────────────────
+
+/// Starts at 0, increments once per unique participant, not per top-up.
+#[test]
+fn test_get_pool_participants_count_unique_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, token_admin_client, _, _, creator) = setup(&env);
+
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let user_c = Address::generate(&env);
+    token_admin_client.mint(&user_a, &1_000_000i128);
+    token_admin_client.mint(&user_b, &1_000_000i128);
+    token_admin_client.mint(&user_c, &1_000_000i128);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Participants count test"),
+            metadata_url: String::from_str(&env, "ipfs://participants-test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    // Fresh pool: 0 participants
+    assert_eq!(client.get_pool_participants_count(&pool_id), 0);
+
+    // user_a joins → count = 1
+    client.place_prediction(&user_a, &pool_id, &100i128, &0u32, &None, &None);
+    assert_eq!(client.get_pool_participants_count(&pool_id), 1);
+
+    // user_a tops up (same outcome) → count stays 1
+    client.place_prediction(&user_a, &pool_id, &50i128, &0u32, &None, &None);
+    assert_eq!(client.get_pool_participants_count(&pool_id), 1);
+
+    // user_b joins → count = 2
+    client.place_prediction(&user_b, &pool_id, &200i128, &1u32, &None, &None);
+    assert_eq!(client.get_pool_participants_count(&pool_id), 2);
+
+    // user_c joins → count = 3
+    client.place_prediction(&user_c, &pool_id, &150i128, &0u32, &None, &None);
+    assert_eq!(client.get_pool_participants_count(&pool_id), 3);
+}
+
+/// participants_count on the Pool struct matches get_pool_participants_count.
+#[test]
+fn test_pool_struct_participants_count_matches_getter() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, token_admin_client, _, _, creator) = setup(&env);
+
+    let user = Address::generate(&env);
+    token_admin_client.mint(&user, &1_000_000i128);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Struct sync test"),
+            metadata_url: String::from_str(&env, "ipfs://struct-sync"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    client.place_prediction(&user, &pool_id, &100i128, &0u32, &None, &None);
+
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.participants_count, 1);
+    assert_eq!(client.get_pool_participants_count(&pool_id), 1);
+    assert_eq!(
+        pool.participants_count,
+        client.get_pool_participants_count(&pool_id)
+    );
+}


### PR DESCRIPTION
closes: #546 

- Add `participants_count: u32` field to the `Pool` struct (initialized to 0 in `create_pool`).
- In `place_prediction`, increment `pool.participants_count` in the new-participant branch (the `else` arm where `DataKey::PartCnt` is also incremented), so the field stays in sync with the existing `PartCnt` persistent counter.
- Add `pub fn get_pool_participants_count(env: Env, pool_id: u64) -> u32` that reads `pool.participants_count` from the `Pool` struct with a single persistent storage fetch.

Why it was needed (issue #546):
  Frontends want to display "Join 1,245 others in this prediction" to signal pool popularity. The count must be unique-participant-based (top-ups by the same address must not inflate it).

Design notes:
- `DataKey::PartCnt` already existed and was already incremented on first prediction; `pool.participants_count` mirrors it so the getter needs only one storage read (the Pool fetch) instead of two.
- `get_pool_stats` continues to read from `PartCnt` unchanged.
- No new storage key is introduced.

Tests added (test.rs):
- `test_get_pool_participants_count_unique_only`: verifies count starts at 0, increments once per new address, and does NOT increment on top-ups by an existing participant.
- `test_pool_struct_participants_count_matches_getter`: verifies that `Pool.participants_count` and `get_pool_participants_count` return the same value after a prediction is placed.