### PR TITLE
feat(contract): add update_pool_description with pre-participation lock

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -640,6 +640,14 @@ pub struct StakeLimitsUpdatedEvent {
     pub max_stake: i128,
 }
 
+#[contractevent(topics = ["pool_description_updated"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PoolDescriptionUpdatedEvent {
+    pub pool_id: u64,
+    pub caller: Address,
+    pub new_description: String,
+}
+
 #[contractevent(topics = ["prediction_placed"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PredictionPlacedEvent {
@@ -1882,6 +1890,83 @@ impl PredifiContract {
         pool.max_total_stake = new_max_total_stake;
         env.storage().persistent().set(&pool_key, &pool);
         Self::extend_persistent(&env, &pool_key);
+
+        Ok(())
+    }
+
+    /// Update the description of a pool before any participant has joined.
+    ///
+    /// Allows the pool creator or a protocol admin to correct a typo or clarify
+    /// ambiguous wording. Once the first prediction is placed the description is
+    /// locked to prevent fraud.
+    ///
+    /// # Arguments
+    /// * `caller`   - Pool creator **or** an address with Admin role (0).
+    /// * `pool_id`  - The pool to update.
+    /// * `new_desc` - Replacement description (max 256 bytes, must be non-empty).
+    ///
+    /// # Errors
+    /// * `Unauthorized`     – caller is neither the creator nor an admin.
+    /// * `InvalidPoolState` – pool is not `Active`, has ended, or already has participants.
+    /// * `InvalidAmount`    – description is empty or exceeds 256 bytes.
+    pub fn update_pool_description(
+        env: Env,
+        caller: Address,
+        pool_id: u64,
+        new_desc: String,
+    ) -> Result<(), PredifiError> {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        let pool_key = DataKey::Pool(pool_id);
+        let mut pool: Pool = env
+            .storage()
+            .persistent()
+            .get(&pool_key)
+            .expect("Pool not found");
+        Self::extend_persistent(&env, &pool_key);
+
+        // Only the creator or a protocol admin may update the description.
+        let is_creator = pool.creator == caller;
+        let is_admin = Self::require_admin_role(&env, &caller, "update_pool_description").is_ok();
+        if !is_creator && !is_admin {
+            return Err(PredifiError::Unauthorized);
+        }
+
+        // Pool must still be active (not resolved or canceled).
+        if !Self::is_pool_active(&pool) {
+            return Err(PredifiError::InvalidPoolState);
+        }
+
+        // Pool must not have ended.
+        if env.ledger().timestamp() >= pool.end_time {
+            return Err(PredifiError::InvalidPoolState);
+        }
+
+        // Lock the description once any participant has joined — equivalent to
+        // "pool has started" in this contract's model (no separate start_time).
+        // We read the PartCnt key which is the authoritative participant counter.
+        let pc_key = DataKey::PartCnt(pool_id);
+        let participants: u32 = env.storage().persistent().get(&pc_key).unwrap_or(0);
+        if participants > 0 {
+            return Err(PredifiError::InvalidPoolState);
+        }
+
+        // Validate the new description: non-empty and within the 256-byte limit.
+        if new_desc.is_empty() || new_desc.len() > 256 {
+            return Err(PredifiError::InvalidAmount);
+        }
+
+        pool.description = new_desc.clone();
+        env.storage().persistent().set(&pool_key, &pool);
+        Self::extend_persistent(&env, &pool_key);
+
+        PoolDescriptionUpdatedEvent {
+            pool_id,
+            caller,
+            new_description: new_desc,
+        }
+        .publish(&env);
 
         Ok(())
     }

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -8366,3 +8366,182 @@ fn test_create_pool_accepts_positive_min_total_stake() {
     let pool = client.get_pool(&pool_id);
     assert_eq!(pool.min_total_stake, 100i128);
 }
+
+// ── update_pool_description tests ────────────────────────────────────────────
+
+/// Creator can update the description before any prediction is placed.
+#[test]
+fn test_update_pool_description_by_creator_before_predictions() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, _, _, _, creator) = setup(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Will BTC hit 100k?"),
+            metadata_url: String::from_str(&env, "ipfs://desc-test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    let new_desc = String::from_str(&env, "Will BTC hit 100k by March 1st?");
+    client.update_pool_description(&creator, &pool_id, &new_desc);
+
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.description, new_desc);
+}
+#[test]
+fn test_update_pool_description_by_admin_before_predictions() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, token_address, _, _, _, _, creator) = setup(&env);
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Original description"),
+            metadata_url: String::from_str(&env, "ipfs://admin-desc-test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    let new_desc = String::from_str(&env, "Admin-corrected description");
+    client.update_pool_description(&admin, &pool_id, &new_desc);
+
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.description, new_desc);
+}
+
+/// Description update is rejected once a prediction has been placed (pool "started").
+#[test]
+fn test_update_pool_description_locked_after_prediction() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, token_admin_client, _, _, creator) = setup(&env);
+
+    let user = Address::generate(&env);
+    token_admin_client.mint(&user, &1_000_000i128);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Original description"),
+            metadata_url: String::from_str(&env, "ipfs://locked-desc-test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    // Place a prediction — this "starts" the pool
+    client.place_prediction(&user, &pool_id, &100i128, &0u32, &None, &None);
+
+    // Description update must now be rejected
+    let result = client.try_update_pool_description(
+        &creator,
+        &pool_id,
+        &String::from_str(&env, "Attempted change after start"),
+    );
+    assert_eq!(result, Err(Ok(PredifiError::InvalidPoolState)));
+
+    // Description must remain unchanged
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(
+        pool.description,
+        String::from_str(&env, "Original description")
+    );
+}
+
+/// Non-creator, non-admin caller is rejected.
+#[test]
+fn test_update_pool_description_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, _, _, _, creator) = setup(&env);
+    let stranger = Address::generate(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Original description"),
+            metadata_url: String::from_str(&env, "ipfs://unauth-desc-test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    let result = client.try_update_pool_description(
+        &stranger,
+        &pool_id,
+        &String::from_str(&env, "Unauthorized change"),
+    );
+    assert_eq!(result, Err(Ok(PredifiError::Unauthorized)));
+}


### PR DESCRIPTION
Add `PoolDescriptionUpdatedEvent` (topic: "pool_description_updated") and `pub fn update_pool_description(env, caller, pool_id, new_desc)`.
 closes: #547 
Guards enforced:
- Contract must not be paused.
- `caller.require_auth()` — explicit auth check.
- Caller must be the pool creator OR hold Admin role (0); any other address is rejected with `PredifiError::Unauthorized`.
- Pool must be in `Active` state (not resolved or canceled).
- Pool must not have passed its `end_time`.
- `DataKey::PartCnt(pool_id)` must be 0 — once the first prediction is placed the description is locked to prevent fraud. This is the contract-native equivalent of "before the pool starts" since there is no separate `start_time` or `Pending` state in this model.
- `new_desc` must be non-empty and ≤ 256 bytes.

Why it was needed (issue #547):
  Pool creators occasionally have typos or ambiguous wording (e.g. "Will BTC hit 100k?" vs "Will BTC hit 100k by March 1st?"). Allowing a correction window before any participant has joined is safe and improves UX without enabling fraud.

Assumptions:
- The contract has no `start_time` / `Pending` state; "before the pool starts" is interpreted as "before the first prediction is placed".
- The `new_desc` parameter is `String` (Soroban SDK type) to match the existing `Pool.description` field type; the issue's mention of `Symbol` is adapted accordingly.
- Both creator and admin are permitted callers, matching the issue's "creator or admin" wording.

Tests added (test.rs):
- `test_update_pool_description_by_creator_before_predictions`
- `test_update_pool_description_by_admin_before_predictions`
- `test_update_pool_description_locked_after_prediction`
- `test_update_pool_description_unauthorized`