### PR TITLE
feature: auto-cancel overdue pools

### DIFF
--- a/contract/contracts/predifi-contract/src/constants.rs
+++ b/contract/contracts/predifi-contract/src/constants.rs
@@ -27,6 +27,10 @@ pub const BUMP_AMOUNT: u32 = 30 * DAY_IN_LEDGERS;
 /// Pools must be active for at least this duration before they can end.
 pub const DEFAULT_MIN_POOL_DURATION: u64 = 3600;
 
+/// Cancellation delay in seconds for overdue pools (7 days).
+/// After this period past the pool's end_time, any user can cancel the pool.
+pub const CANCELATION_DELAY: u64 = 604800;
+
 /// Default global minimum stake amount (1 unit in base token units).
 /// Predictions below this threshold are rejected to prevent spam.
 pub const DEFAULT_GLOBAL_MIN_STAKE: i128 = 1;

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -2323,12 +2323,21 @@ impl PredifiContract {
             || Self::require_role(&env, &operator, 1).is_ok();
 
         if !is_privileged {
-            // Allow creator to cancel only if no bets have been placed beyond initial liquidity
-            if operator != pool.creator {
-                return Err(PredifiError::Unauthorized);
-            }
-            if pool.total_stake > pool.initial_liquidity {
-                return Err(PredifiError::Unauthorized);
+            // Check if pool is overdue (past end_time + CANCELATION_DELAY)
+            let current_time = env.ledger().timestamp();
+            let overdue_threshold = pool.end_time + CANCELATION_DELAY;
+            
+            if current_time > overdue_threshold {
+                // Allow any user to cancel overdue pools
+                // This is a failsafe to unlock funds when resolution is delayed
+            } else {
+                // Allow creator to cancel only if no bets have been placed beyond initial liquidity
+                if operator != pool.creator {
+                    return Err(PredifiError::Unauthorized);
+                }
+                if pool.total_stake > pool.initial_liquidity {
+                    return Err(PredifiError::Unauthorized);
+                }
             }
         }
 

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -2326,7 +2326,7 @@ impl PredifiContract {
             // Check if pool is overdue (past end_time + CANCELATION_DELAY)
             let current_time = env.ledger().timestamp();
             let overdue_threshold = pool.end_time + CANCELATION_DELAY;
-            
+
             if current_time > overdue_threshold {
                 // Allow any user to cancel overdue pools
                 // This is a failsafe to unlock funds when resolution is delayed

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -7860,6 +7860,84 @@ fn test_cancel_pool_zero_participants_no_contract_balance_change() {
     assert_eq!(balance_before, balance_after);
 }
 
+/// Test that any user can cancel a pool that is overdue (past end_time + CANCELATION_DELAY)
+#[test]
+fn test_any_user_can_cancel_overdue_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, token_admin_client, _, _operator, creator) = setup(&env);
+
+    // Set current time and create a pool
+    let current_time = 10000u64;
+    env.ledger().with_mut(|li| li.timestamp = current_time);
+    
+    let end_time = current_time + 3600u64; // Pool ends 1 hour from now
+    let pool_id = client.create_pool(
+        &creator,
+        &end_time,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Overdue Pool"),
+            metadata_url: String::from_str(&env, "ipfs://overdue"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    // Place some predictions to lock funds
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    token_admin_client.mint(&user1, &1000);
+    token_admin_client.mint(&user2, &1000);
+
+    client.place_prediction(&user1, &pool_id, &100, &0, &None, &None);
+    client.place_prediction(&user2, &pool_id, &200, &1, &None, &None);
+
+    // Advance time to just before the pool becomes overdue (end_time + CANCELATION_DELAY - 1)
+    let just_before_overdue = end_time + CANCELATION_DELAY - 1;
+    env.ledger().with_mut(|li| li.timestamp = just_before_overdue);
+
+    // Regular user should NOT be able to cancel yet (not overdue)
+    let random_user = Address::generate(&env);
+    let result = client.try_cancel_pool(&random_user, &pool_id, &String::from_str(&env, "Not overdue yet"));
+    assert!(result.is_err(), "Regular user should not be able to cancel before overdue period");
+
+    // Advance time to make the pool overdue (8 days after end_time)
+    let overdue_time = end_time + CANCELATION_DELAY + 86400; // 8 days = 7 days + 1 day
+    env.ledger().with_mut(|li| li.timestamp = overdue_time);
+
+    // Now any user should be able to cancel the overdue pool
+    client.cancel_pool(&random_user, &pool_id, &String::from_str(&env, "Pool is overdue"));
+
+    // Verify pool is canceled
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.state, MarketState::Canceled);
+    assert!(pool.canceled);
+
+    // Users should be able to claim refunds
+    let refund1 = client.claim_refund(&user1, &pool_id);
+    assert_eq!(refund1, 100);
+    assert_eq!(token_admin_client.balance(&user1), 1000); // Initial 1000 - 100 stake + 100 refund
+
+    let refund2 = client.claim_refund(&user2, &pool_id);
+    assert_eq!(refund2, 200);
+    assert_eq!(token_admin_client.balance(&user2), 1000); // Initial 1000 - 200 stake + 200 refund
+}
+
 #[test]
 fn test_claim_refund_on_zero_participant_canceled_pool_returns_error() {
     let env = Env::default();

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -7871,7 +7871,7 @@ fn test_any_user_can_cancel_overdue_pool() {
     // Set current time and create a pool
     let current_time = 10000u64;
     env.ledger().with_mut(|li| li.timestamp = current_time);
-    
+
     let end_time = current_time + 3600u64; // Pool ends 1 hour from now
     let pool_id = client.create_pool(
         &creator,
@@ -7909,19 +7909,31 @@ fn test_any_user_can_cancel_overdue_pool() {
 
     // Advance time to just before the pool becomes overdue (end_time + CANCELATION_DELAY - 1)
     let just_before_overdue = end_time + CANCELATION_DELAY - 1;
-    env.ledger().with_mut(|li| li.timestamp = just_before_overdue);
+    env.ledger()
+        .with_mut(|li| li.timestamp = just_before_overdue);
 
     // Regular user should NOT be able to cancel yet (not overdue)
     let random_user = Address::generate(&env);
-    let result = client.try_cancel_pool(&random_user, &pool_id, &String::from_str(&env, "Not overdue yet"));
-    assert!(result.is_err(), "Regular user should not be able to cancel before overdue period");
+    let result = client.try_cancel_pool(
+        &random_user,
+        &pool_id,
+        &String::from_str(&env, "Not overdue yet"),
+    );
+    assert!(
+        result.is_err(),
+        "Regular user should not be able to cancel before overdue period"
+    );
 
     // Advance time to make the pool overdue (8 days after end_time)
     let overdue_time = end_time + CANCELATION_DELAY + 86400; // 8 days = 7 days + 1 day
     env.ledger().with_mut(|li| li.timestamp = overdue_time);
 
     // Now any user should be able to cancel the overdue pool
-    client.cancel_pool(&random_user, &pool_id, &String::from_str(&env, "Pool is overdue"));
+    client.cancel_pool(
+        &random_user,
+        &pool_id,
+        &String::from_str(&env, "Pool is overdue"),
+    );
 
     // Verify pool is canceled
     let pool = client.get_pool(&pool_id);


### PR DESCRIPTION
## Description

Implements a **permissionless cancellation failsafe** for overdue prediction pools. Previously, only admins, operators, or the pool creator (under specific conditions) could cancel a pool. This left user funds potentially locked indefinitely if a pool passed its end time but was never resolved.

With this change, any user can cancel a pool once it has been unresolved for more than `CANCELATION_DELAY` (7 days) past its `end_time`. This acts as a last-resort unlock mechanism, ensuring funds are never permanently stranded due to operator inaction or resolution failure.

Key changes:
- Added `CANCELATION_DELAY: u64 = 604800` (7 days in seconds) constant to `constants.rs`
- Updated `cancel_pool` authorization logic: when `current_time > pool.end_time + CANCELATION_DELAY`, the privileged-role check is bypassed and any caller may cancel
- Non-privileged, non-creator users are still blocked from cancelling pools that are not yet overdue — existing behaviour is fully preserved for the normal cancellation window

Closes #550

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

> No existing cancellation paths are removed or altered. The overdue path is an additive branch that only activates after the 7-day grace period.

## How Has This Been Tested?

The following test case was added to `src/test.rs`:

- **`test_any_user_can_cancel_overdue_pool`** — full end-to-end scenario:
  1. A pool is created with a future `end_time` and two users place predictions, locking funds
  2. Time is advanced to `end_time + CANCELATION_DELAY - 1` (one second before the threshold) — a random user attempts to cancel and is correctly rejected
  3. Time is advanced past the threshold (`end_time + CANCELATION_DELAY + 86400`) — the same random user successfully cancels the pool
  4. Pool state is verified as `Canceled`
  5. Both staking users claim full refunds and their balances are confirmed to be restored

All previously existing cancellation tests continue to pass, confirming no regression in the privileged-path behaviour.

To reproduce, run:
```bash
cargo test -p predifi-contract
```

## Screenshots / Recordings

N/A — no frontend/UI changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules