### PR TITLE
Feature/get supported tokens

### DIFF
--- a/contract/contracts/predifi-contract/src/constants.rs
+++ b/contract/contracts/predifi-contract/src/constants.rs
@@ -27,6 +27,10 @@ pub const BUMP_AMOUNT: u32 = 30 * DAY_IN_LEDGERS;
 /// Pools must be active for at least this duration before they can end.
 pub const DEFAULT_MIN_POOL_DURATION: u64 = 3600;
 
+/// Cancellation delay in seconds for overdue pools (7 days).
+/// After this period past the pool's end_time, any user can cancel the pool.
+pub const CANCELATION_DELAY: u64 = 604800;
+
 /// Default global minimum stake amount (1 unit in base token units).
 /// Predictions below this threshold are rejected to prevent spam.
 pub const DEFAULT_GLOBAL_MIN_STAKE: i128 = 1;

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -2323,12 +2323,21 @@ impl PredifiContract {
             || Self::require_role(&env, &operator, 1).is_ok();
 
         if !is_privileged {
-            // Allow creator to cancel only if no bets have been placed beyond initial liquidity
-            if operator != pool.creator {
-                return Err(PredifiError::Unauthorized);
-            }
-            if pool.total_stake > pool.initial_liquidity {
-                return Err(PredifiError::Unauthorized);
+            // Check if pool is overdue (past end_time + CANCELATION_DELAY)
+            let current_time = env.ledger().timestamp();
+            let overdue_threshold = pool.end_time + CANCELATION_DELAY;
+            
+            if current_time > overdue_threshold {
+                // Allow any user to cancel overdue pools
+                // This is a failsafe to unlock funds when resolution is delayed
+            } else {
+                // Allow creator to cancel only if no bets have been placed beyond initial liquidity
+                if operator != pool.creator {
+                    return Err(PredifiError::Unauthorized);
+                }
+                if pool.total_stake > pool.initial_liquidity {
+                    return Err(PredifiError::Unauthorized);
+                }
             }
         }
 

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -1550,7 +1550,7 @@ impl PredifiContract {
             .persistent()
             .get(&whitelist_key)
             .unwrap_or_else(|| Vec::new(&env));
-        
+
         // Only add if not already in the list
         if !whitelist.contains(&token) {
             whitelist.push_back(token.clone());
@@ -1585,7 +1585,7 @@ impl PredifiContract {
             .persistent()
             .get(&whitelist_key)
             .unwrap_or_else(|| Vec::new(&env));
-        
+
         // Remove the token from the list if present
         let new_whitelist = Vec::new(&env);
         let mut new_whitelist = new_whitelist;
@@ -1595,7 +1595,7 @@ impl PredifiContract {
             }
         }
         whitelist = new_whitelist;
-        
+
         env.storage().persistent().set(&whitelist_key, &whitelist);
         Self::extend_persistent(&env, &whitelist_key);
 
@@ -1616,11 +1616,11 @@ impl PredifiContract {
             .persistent()
             .get(&whitelist_key)
             .unwrap_or_else(|| Vec::new(&env));
-        
+
         if env.storage().persistent().has(&whitelist_key) {
             Self::extend_persistent(&env, &whitelist_key);
         }
-        
+
         whitelist
     }
 

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -485,6 +485,10 @@ pub enum DataKey {
     ///
     /// Present (with value `true`) when the token is allowed for betting.
     TokenWl(Address),
+    /// Whitelisted tokens list: `TokenWhitelist` -> `Vec<Address>`
+    ///
+    /// Maintains an ordered list of all whitelisted token addresses for efficient enumeration.
+    TokenWhitelist,
 
     // ── Categories ───────────────────────────────────────────────────────────
     /// Category pool count: `CatPoolCt(category)` -> `u32`
@@ -1539,6 +1543,21 @@ impl PredifiContract {
         env.storage().persistent().set(&key, &true);
         Self::extend_persistent(&env, &key);
 
+        // Add to the whitelist list if not already present
+        let whitelist_key = DataKey::TokenWhitelist;
+        let mut whitelist: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&whitelist_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        
+        // Only add if not already in the list
+        if !whitelist.contains(&token) {
+            whitelist.push_back(token.clone());
+            env.storage().persistent().set(&whitelist_key, &whitelist);
+            Self::extend_persistent(&env, &whitelist_key);
+        }
+
         TokenWhitelistAddedEvent {
             admin: admin.clone(),
             token: token.clone(),
@@ -1559,12 +1578,50 @@ impl PredifiContract {
         let key = DataKey::TokenWl(token.clone());
         env.storage().persistent().remove(&key);
 
+        // Remove from the whitelist list
+        let whitelist_key = DataKey::TokenWhitelist;
+        let mut whitelist: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&whitelist_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        
+        // Remove the token from the list if present
+        let new_whitelist = Vec::new(&env);
+        let mut new_whitelist = new_whitelist;
+        for t in whitelist.iter() {
+            if t.clone() != token {
+                new_whitelist.push_back(t);
+            }
+        }
+        whitelist = new_whitelist;
+        
+        env.storage().persistent().set(&whitelist_key, &whitelist);
+        Self::extend_persistent(&env, &whitelist_key);
+
         TokenWhitelistRemovedEvent {
             admin: admin.clone(),
             token: token.clone(),
         }
         .publish(&env);
         Ok(())
+    }
+
+    /// Get the list of all supported (whitelisted) tokens.
+    /// Returns a Vec of token addresses that are allowed for betting.
+    pub fn get_supported_tokens(env: Env) -> Vec<Address> {
+        let whitelist_key = DataKey::TokenWhitelist;
+        let whitelist: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&whitelist_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        
+        if env.storage().persistent().has(&whitelist_key) {
+            Self::extend_persistent(&env, &whitelist_key);
+        }
+        
+        whitelist
     }
 
     /// Upgrade the contract Wasm code. Only callable by Admin (role 0).

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -2326,7 +2326,7 @@ impl PredifiContract {
             // Check if pool is overdue (past end_time + CANCELATION_DELAY)
             let current_time = env.ledger().timestamp();
             let overdue_threshold = pool.end_time + CANCELATION_DELAY;
-            
+
             if current_time > overdue_threshold {
                 // Allow any user to cancel overdue pools
                 // This is a failsafe to unlock funds when resolution is delayed

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -7860,6 +7860,84 @@ fn test_cancel_pool_zero_participants_no_contract_balance_change() {
     assert_eq!(balance_before, balance_after);
 }
 
+/// Test that any user can cancel a pool that is overdue (past end_time + CANCELATION_DELAY)
+#[test]
+fn test_any_user_can_cancel_overdue_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, token_admin_client, _, _operator, creator) = setup(&env);
+
+    // Set current time and create a pool
+    let current_time = 10000u64;
+    env.ledger().with_mut(|li| li.timestamp = current_time);
+    
+    let end_time = current_time + 3600u64; // Pool ends 1 hour from now
+    let pool_id = client.create_pool(
+        &creator,
+        &end_time,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Overdue Pool"),
+            metadata_url: String::from_str(&env, "ipfs://overdue"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    // Place some predictions to lock funds
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    token_admin_client.mint(&user1, &1000);
+    token_admin_client.mint(&user2, &1000);
+
+    client.place_prediction(&user1, &pool_id, &100, &0, &None, &None);
+    client.place_prediction(&user2, &pool_id, &200, &1, &None, &None);
+
+    // Advance time to just before the pool becomes overdue (end_time + CANCELATION_DELAY - 1)
+    let just_before_overdue = end_time + CANCELATION_DELAY - 1;
+    env.ledger().with_mut(|li| li.timestamp = just_before_overdue);
+
+    // Regular user should NOT be able to cancel yet (not overdue)
+    let random_user = Address::generate(&env);
+    let result = client.try_cancel_pool(&random_user, &pool_id, &String::from_str(&env, "Not overdue yet"));
+    assert!(result.is_err(), "Regular user should not be able to cancel before overdue period");
+
+    // Advance time to make the pool overdue (8 days after end_time)
+    let overdue_time = end_time + CANCELATION_DELAY + 86400; // 8 days = 7 days + 1 day
+    env.ledger().with_mut(|li| li.timestamp = overdue_time);
+
+    // Now any user should be able to cancel the overdue pool
+    client.cancel_pool(&random_user, &pool_id, &String::from_str(&env, "Pool is overdue"));
+
+    // Verify pool is canceled
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.state, MarketState::Canceled);
+    assert!(pool.canceled);
+
+    // Users should be able to claim refunds
+    let refund1 = client.claim_refund(&user1, &pool_id);
+    assert_eq!(refund1, 100);
+    assert_eq!(token_admin_client.balance(&user1), 1000); // Initial 1000 - 100 stake + 100 refund
+
+    let refund2 = client.claim_refund(&user2, &pool_id);
+    assert_eq!(refund2, 200);
+    assert_eq!(token_admin_client.balance(&user2), 1000); // Initial 1000 - 200 stake + 200 refund
+}
+
 #[test]
 fn test_claim_refund_on_zero_participant_canceled_pool_returns_error() {
     let env = Env::default();

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -8482,6 +8482,79 @@ fn test_whitelist_events_emitted() {
     assert!(!client.is_whitelisted(&pool_id, &user));
 }
 
+/// Test get_supported_tokens returns empty list when no tokens are whitelisted
+#[test]
+fn test_get_supported_tokens_empty() {
+    let (_env, client, _admin, _treasury) = setup_whitelist_env();
+    
+    let supported_tokens = client.get_supported_tokens();
+    assert_eq!(supported_tokens.len(), 0);
+}
+
+/// Test get_supported_tokens returns list of whitelisted tokens
+#[test]
+fn test_get_supported_tokens_multiple() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    let token_c = Address::generate(&env);
+    
+    // Add tokens to whitelist
+    client.add_token_to_whitelist(&admin, &token_a);
+    client.add_token_to_whitelist(&admin, &token_b);
+    client.add_token_to_whitelist(&admin, &token_c);
+    
+    let supported_tokens = client.get_supported_tokens();
+    assert_eq!(supported_tokens.len(), 3);
+    assert!(supported_tokens.contains(&token_a));
+    assert!(supported_tokens.contains(&token_b));
+    assert!(supported_tokens.contains(&token_c));
+}
+
+/// Test get_supported_tokens updates correctly when tokens are removed
+#[test]
+fn test_get_supported_tokens_after_removal() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    let token_c = Address::generate(&env);
+    
+    // Add tokens to whitelist
+    client.add_token_to_whitelist(&admin, &token_a);
+    client.add_token_to_whitelist(&admin, &token_b);
+    client.add_token_to_whitelist(&admin, &token_c);
+    
+    let supported_tokens = client.get_supported_tokens();
+    assert_eq!(supported_tokens.len(), 3);
+    
+    // Remove one token
+    client.remove_token_from_whitelist(&admin, &token_b);
+    
+    let supported_tokens = client.get_supported_tokens();
+    assert_eq!(supported_tokens.len(), 2);
+    assert!(supported_tokens.contains(&token_a));
+    assert!(supported_tokens.contains(&token_c));
+    assert!(!supported_tokens.contains(&token_b));
+}
+
+/// Test get_supported_tokens handles duplicate additions gracefully
+#[test]
+fn test_get_supported_tokens_duplicate_additions() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    
+    let token = Address::generate(&env);
+    
+    // Add the same token twice
+    client.add_token_to_whitelist(&admin, &token);
+    client.add_token_to_whitelist(&admin, &token);
+    
+    let supported_tokens = client.get_supported_tokens();
+    assert_eq!(supported_tokens.len(), 1);
+    assert!(supported_tokens.contains(&token));
+}
+
 /// Test that create_pool rejects a min_total_stake of zero.
 ///
 /// Per issue #507: `min_total_stake` must be strictly positive (> 0).

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -7871,7 +7871,7 @@ fn test_any_user_can_cancel_overdue_pool() {
     // Set current time and create a pool
     let current_time = 10000u64;
     env.ledger().with_mut(|li| li.timestamp = current_time);
-    
+
     let end_time = current_time + 3600u64; // Pool ends 1 hour from now
     let pool_id = client.create_pool(
         &creator,
@@ -7909,19 +7909,31 @@ fn test_any_user_can_cancel_overdue_pool() {
 
     // Advance time to just before the pool becomes overdue (end_time + CANCELATION_DELAY - 1)
     let just_before_overdue = end_time + CANCELATION_DELAY - 1;
-    env.ledger().with_mut(|li| li.timestamp = just_before_overdue);
+    env.ledger()
+        .with_mut(|li| li.timestamp = just_before_overdue);
 
     // Regular user should NOT be able to cancel yet (not overdue)
     let random_user = Address::generate(&env);
-    let result = client.try_cancel_pool(&random_user, &pool_id, &String::from_str(&env, "Not overdue yet"));
-    assert!(result.is_err(), "Regular user should not be able to cancel before overdue period");
+    let result = client.try_cancel_pool(
+        &random_user,
+        &pool_id,
+        &String::from_str(&env, "Not overdue yet"),
+    );
+    assert!(
+        result.is_err(),
+        "Regular user should not be able to cancel before overdue period"
+    );
 
     // Advance time to make the pool overdue (8 days after end_time)
     let overdue_time = end_time + CANCELATION_DELAY + 86400; // 8 days = 7 days + 1 day
     env.ledger().with_mut(|li| li.timestamp = overdue_time);
 
     // Now any user should be able to cancel the overdue pool
-    client.cancel_pool(&random_user, &pool_id, &String::from_str(&env, "Pool is overdue"));
+    client.cancel_pool(
+        &random_user,
+        &pool_id,
+        &String::from_str(&env, "Pool is overdue"),
+    );
 
     // Verify pool is canceled
     let pool = client.get_pool(&pool_id);

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -8486,7 +8486,7 @@ fn test_whitelist_events_emitted() {
 #[test]
 fn test_get_supported_tokens_empty() {
     let (_env, client, _admin, _treasury) = setup_whitelist_env();
-    
+
     let supported_tokens = client.get_supported_tokens();
     assert_eq!(supported_tokens.len(), 0);
 }
@@ -8495,16 +8495,16 @@ fn test_get_supported_tokens_empty() {
 #[test]
 fn test_get_supported_tokens_multiple() {
     let (env, client, admin, _treasury) = setup_whitelist_env();
-    
+
     let token_a = Address::generate(&env);
     let token_b = Address::generate(&env);
     let token_c = Address::generate(&env);
-    
+
     // Add tokens to whitelist
     client.add_token_to_whitelist(&admin, &token_a);
     client.add_token_to_whitelist(&admin, &token_b);
     client.add_token_to_whitelist(&admin, &token_c);
-    
+
     let supported_tokens = client.get_supported_tokens();
     assert_eq!(supported_tokens.len(), 3);
     assert!(supported_tokens.contains(&token_a));
@@ -8516,22 +8516,22 @@ fn test_get_supported_tokens_multiple() {
 #[test]
 fn test_get_supported_tokens_after_removal() {
     let (env, client, admin, _treasury) = setup_whitelist_env();
-    
+
     let token_a = Address::generate(&env);
     let token_b = Address::generate(&env);
     let token_c = Address::generate(&env);
-    
+
     // Add tokens to whitelist
     client.add_token_to_whitelist(&admin, &token_a);
     client.add_token_to_whitelist(&admin, &token_b);
     client.add_token_to_whitelist(&admin, &token_c);
-    
+
     let supported_tokens = client.get_supported_tokens();
     assert_eq!(supported_tokens.len(), 3);
-    
+
     // Remove one token
     client.remove_token_from_whitelist(&admin, &token_b);
-    
+
     let supported_tokens = client.get_supported_tokens();
     assert_eq!(supported_tokens.len(), 2);
     assert!(supported_tokens.contains(&token_a));
@@ -8543,13 +8543,13 @@ fn test_get_supported_tokens_after_removal() {
 #[test]
 fn test_get_supported_tokens_duplicate_additions() {
     let (env, client, admin, _treasury) = setup_whitelist_env();
-    
+
     let token = Address::generate(&env);
-    
+
     // Add the same token twice
     client.add_token_to_whitelist(&admin, &token);
     client.add_token_to_whitelist(&admin, &token);
-    
+
     let supported_tokens = client.get_supported_tokens();
     assert_eq!(supported_tokens.len(), 1);
     assert!(supported_tokens.contains(&token));


### PR DESCRIPTION
## Description

Implements `get_supported_tokens` to give the frontend an efficient, on-chain enumerable list of all whitelisted tokens. Previously, the token whitelist was only queryable per-address via `is_token_allowed`, meaning the frontend had no way to discover which tokens are supported without guessing. This PR closes that gap.

Key changes:
- Added `DataKey::TokenWhitelist` variant — a new persistent `Vec<Address>` that tracks all whitelisted token addresses in insertion order
- Updated `add_token_to_whitelist` to push to the list on each new addition, with a duplicate guard so re-adding an existing token does not create duplicates
- Updated `remove_token_from_whitelist` to rebuild the list without the removed token, keeping it in sync with the per-address `TokenWl` keys
- Added `get_supported_tokens(env: Env) -> Vec<Address>` — reads and returns the list directly, extending TTL on access

This also includes the overdue pool cancellation failsafe from the previous change (`CANCELATION_DELAY` constant + permissionless cancel path), combined into this branch.

Closes #549

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

> All existing whitelist behaviour is fully preserved. `get_supported_tokens` is purely additive and the list is kept consistent with the existing `TokenWl` per-address keys.

## How Has This Been Tested?

The following test cases were added to `src/test.rs`:

- **`test_get_supported_tokens_empty`** — verifies the function returns an empty list when no tokens have been whitelisted
- **`test_get_supported_tokens_multiple`** — adds three tokens and confirms all three appear in the returned list
- **`test_get_supported_tokens_after_removal`** — adds three tokens, removes one, and verifies the returned list reflects the removal correctly
- **`test_get_supported_tokens_duplicate_additions`** — adds the same token twice and confirms the list contains exactly one entry, validating the duplicate guard

All previously existing whitelist and cancellation tests continue to pass with no regression.

To reproduce, run:
```bash
cargo test -p predifi-contract
```

## Screenshots / Recordings

N/A — no frontend/UI changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules