### PR TITLE
fix(access-control): add propose/accept admin transfer

### DIFF
--- a/contract/contracts/access-control/src/lib.rs
+++ b/contract/contracts/access-control/src/lib.rs
@@ -43,7 +43,8 @@
 //    - `revoke_role`: Remove a specific role from a user
 //    - `transfer_role`: Move a role from one user to another
 //    - `revoke_all_roles`: Remove all roles from a user
-//    - `transfer_admin`: Transfer admin authority to a new address
+//    - `propose_new_admin` + `accept_admin_role`: Two-step admin transfer
+//    - `transfer_admin`: Legacy one-step admin transfer
 // 4. Any contract can check if a user has a role by calling `has_role(user, role)`.
 // 5. The `has_any_role` function allows checking if a user has any of a set of roles.
 //
@@ -51,7 +52,7 @@
 // ───────────────────────
 // - Only the admin can assign or revoke roles
 // - All admin operations require authentication (`require_auth`)
-// - Admin transfer is irreversible - the old admin loses all privileges
+// - Admin transfer supports a two-step propose/accept flow for safety
 // - Role checks are performed via storage lookups in persistent storage
 //
 // ═══════════════════════════════════════════════════════════════════════════
@@ -123,6 +124,13 @@ pub struct AdminTransferredEvent {
     pub new_admin: Address,
 }
 
+#[contractevent(topics = ["admin_transfer_proposed"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferProposedEvent {
+    pub admin: Address,
+    pub proposed_admin: Address,
+}
+
 #[contractevent(topics = ["all_roles_revoked"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AllRolesRevokedEvent {
@@ -173,6 +181,8 @@ pub enum PoolCategory {
 pub enum DataKey {
     /// Admin address: Admin -> Address
     Admin,
+    /// Proposed admin address awaiting acceptance: ProposedAdmin -> Address
+    ProposedAdmin,
     /// Role assignment: Role(user_address, role) -> ()
     Role(Address, Role),
     /// Pool data: Pool(pool_id) -> Pool
@@ -205,6 +215,10 @@ impl AccessControl {
             .instance()
             .get(&DataKey::Admin)
             .expect("NotInitialized")
+    }
+
+    pub fn get_proposed_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::ProposedAdmin)
     }
 
     pub fn assign_role(
@@ -369,17 +383,55 @@ impl AccessControl {
             return Err(PrediFiError::Unauthorized);
         }
 
-        env.storage().instance().set(&DataKey::Admin, &new_admin);
-
-        env.storage()
-            .persistent()
-            .remove(&DataKey::Role(current_admin, Role::Admin));
-        env.storage()
-            .persistent()
-            .set(&DataKey::Role(new_admin.clone(), Role::Admin), &());
+        Self::apply_admin_transfer(&env, current_admin.clone(), new_admin.clone());
 
         AdminTransferredEvent {
-            admin: admin_caller,
+            admin: current_admin,
+            new_admin,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn propose_new_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), PrediFiError> {
+        current_admin.require_auth();
+
+        let stored_admin = Self::get_admin(env.clone());
+        if current_admin != stored_admin {
+            return Err(PrediFiError::Unauthorized);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposedAdmin, &new_admin);
+
+        AdminTransferProposedEvent {
+            admin: current_admin,
+            proposed_admin: new_admin,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn accept_admin_role(env: Env, new_admin: Address) -> Result<(), PrediFiError> {
+        new_admin.require_auth();
+
+        let proposed_admin: Option<Address> = env.storage().instance().get(&DataKey::ProposedAdmin);
+        if proposed_admin != Some(new_admin.clone()) {
+            return Err(PrediFiError::Unauthorized);
+        }
+
+        let current_admin = Self::get_admin(env.clone());
+        Self::apply_admin_transfer(&env, current_admin.clone(), new_admin.clone());
+
+        AdminTransferredEvent {
+            admin: current_admin,
             new_admin,
         }
         .publish(&env);
@@ -467,6 +519,18 @@ impl AccessControl {
             .instance()
             .get(&DataKey::OperatorCount)
             .unwrap_or(0)
+    }
+
+    fn apply_admin_transfer(env: &Env, current_admin: Address, new_admin: Address) {
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.storage().instance().remove(&DataKey::ProposedAdmin);
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Role(current_admin, Role::Admin));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Role(new_admin.clone(), Role::Admin), &());
     }
 }
 

--- a/contract/contracts/access-control/src/test.rs
+++ b/contract/contracts/access-control/src/test.rs
@@ -108,6 +108,53 @@ fn test_admin_transfer() {
 }
 
 #[test]
+fn test_propose_and_accept_admin_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AccessControl, ());
+    let client = AccessControlClient::new(&env, &contract_id);
+
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+
+    client.init(&admin1);
+    client.propose_new_admin(&admin1, &admin2);
+
+    assert_eq!(client.get_admin(), admin1);
+    assert_eq!(client.get_proposed_admin(), Some(admin2.clone()));
+
+    client.accept_admin_role(&admin2);
+
+    assert_eq!(client.get_admin(), admin2.clone());
+    assert_eq!(client.get_proposed_admin(), None);
+    assert!(client.has_role(&admin2, &Role::Admin));
+    assert!(!client.has_role(&admin1, &Role::Admin));
+}
+
+#[test]
+fn test_only_proposed_admin_can_accept_admin_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AccessControl, ());
+    let client = AccessControlClient::new(&env, &contract_id);
+
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    let random_user = Address::generate(&env);
+
+    client.init(&admin1);
+    client.propose_new_admin(&admin1, &admin2);
+
+    let result = client.try_accept_admin_role(&random_user);
+    assert_eq!(result, Err(Ok(PrediFiError::Unauthorized)));
+
+    assert_eq!(client.get_admin(), admin1);
+    assert_eq!(client.get_proposed_admin(), Some(admin2));
+}
+
+#[test]
 fn test_unauthorized_assignment() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #551

## Summary
Implements a targeted two-step admin ownership transfer flow in the access-control contract using a **propose + accept** pattern.

## Changes
- Added `DataKey::ProposedAdmin` storage key.
- Added `get_proposed_admin(env: Env) -> Option<Address>`.
- Added `propose_new_admin(env, current_admin, new_admin)`.
- Added `accept_admin_role(env, new_admin)`.
- Enforced that only the proposed admin can accept (`Unauthorized` otherwise).
- Added `AdminTransferProposedEvent` (`admin_transfer_proposed`).
- Refactored admin state updates into a shared internal helper to keep role/admin updates consistent.
- Kept existing `transfer_admin` behavior intact (legacy one-step path still works).

## Tests
- Added `test_propose_and_accept_admin_transfer`.
- Added `test_only_proposed_admin_can_accept_admin_role`.

## Verification
- Ran `cargo fmt --all`.
- Could not run `cargo test -p access-control` in this environment because `link.exe` (MSVC toolchain) is missing.
