### PR TITLE
feat(predifi-contract): add aggregated contract metadata getter

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -388,6 +388,39 @@ pub struct FeeInfo {
     pub referral_fee_bps: u32,
 }
 
+/// Aggregated contract metadata for frontend consumption.
+///
+/// This read model allows clients to fetch protocol configuration and core stats
+/// in one call instead of performing multiple separate getters.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractInfo {
+    /// Contract version tracked in instance storage.
+    pub version: u32,
+    /// Admin address from the access-control contract.
+    pub current_admin: Address,
+    /// Whether the contract is currently paused.
+    pub is_paused: bool,
+    /// Total number of pools created so far.
+    pub total_pools: u64,
+    /// Protocol fee in basis points (1 bp = 0.01%).
+    pub fee_bps: u32,
+    /// Referral fee cut in basis points.
+    pub referral_cut_bps: u32,
+    /// Treasury address that receives protocol fees.
+    pub treasury: Address,
+    /// Access-control contract address.
+    pub access_control: Address,
+    /// Global resolution delay in seconds.
+    pub resolution_delay: u64,
+    /// Minimum pool duration in seconds.
+    pub min_pool_duration: u64,
+    /// Global minimum stake.
+    pub min_stake: i128,
+    /// Maximum predictions allowed per user per pool.
+    pub max_predictions_per_user: u32,
+}
+
 /// Represents a fee tier within the protocol's dynamic fee system.
 ///
 /// Fee tiers allow the protocol to adjust fees based on the pool's total volume (stake).
@@ -1100,6 +1133,14 @@ impl PredifiContract {
         )
     }
 
+    fn get_access_control_admin(env: &Env, contract: &Address) -> Address {
+        env.invoke_contract(
+            contract,
+            &Symbol::new(env, "get_admin"),
+            soroban_sdk::vec![env],
+        )
+    }
+
     fn require_role(env: &Env, user: &Address, role: u32) -> Result<(), PredifiError> {
         let config = Self::get_config(env);
         if !Self::has_role(env, &config.access_control, user, role) {
@@ -1671,6 +1712,35 @@ impl PredifiContract {
         FeeInfo {
             treasury_fee_bps: Self::get_config(&env).fee_bps,
             referral_fee_bps: Self::read_referral_cut_bps(&env),
+        }
+    }
+
+    /// Return an aggregated metadata view of contract config and protocol state.
+    pub fn get_contract_info(env: Env) -> ContractInfo {
+        let config = Self::get_config(&env);
+        let current_admin = Self::get_access_control_admin(&env, &config.access_control);
+
+        ContractInfo {
+            version: env
+                .storage()
+                .instance()
+                .get(&DataKey::Version)
+                .unwrap_or(0u32),
+            current_admin,
+            is_paused: Self::is_paused(&env),
+            total_pools: env
+                .storage()
+                .instance()
+                .get(&DataKey::PoolIdCtr)
+                .unwrap_or(0u64),
+            fee_bps: config.fee_bps,
+            referral_cut_bps: Self::read_referral_cut_bps(&env),
+            treasury: config.treasury,
+            access_control: config.access_control,
+            resolution_delay: config.resolution_delay,
+            min_pool_duration: config.min_pool_duration,
+            min_stake: config.min_stake,
+            max_predictions_per_user: config.max_predictions_per_user,
         }
     }
 

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -31,6 +31,11 @@ pub(crate) mod dummy_access_control {
 
             env.storage().instance().set(&already_has_key, &true);
 
+            if role == 0 {
+                let admin_key = Symbol::new(&env, "admin");
+                env.storage().instance().set(&admin_key, &user);
+            }
+
             // Track operator count
             if role == 1 && !already_has {
                 let count_key = Symbol::new(&env, "op_count");
@@ -61,6 +66,14 @@ pub(crate) mod dummy_access_control {
         pub fn get_operator_count(env: Env) -> u32 {
             let count_key = Symbol::new(&env, "op_count");
             env.storage().instance().get(&count_key).unwrap_or(0)
+        }
+
+        pub fn get_admin(env: Env) -> Address {
+            let admin_key = Symbol::new(&env, "admin");
+            env.storage()
+                .instance()
+                .get(&admin_key)
+                .expect("admin not set in dummy access control")
         }
     }
 }
@@ -8431,6 +8444,76 @@ fn test_get_fees_returns_treasury_and_referral_fee_bps() {
     let fees = c.get_fees();
     assert_eq!(fees.treasury_fee_bps, 750);
     assert_eq!(fees.referral_fee_bps, 2000);
+}
+
+#[test]
+fn test_get_contract_info_returns_config_and_stats() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, token_address, _, _, _, _, creator) = setup(&env);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let pool_config = PoolConfig {
+        description: String::from_str(&env, "Pool"),
+        metadata_url: String::from_str(&env, "ipfs://pool"),
+        min_stake: 1i128,
+        max_stake: 0i128,
+        max_total_stake: 0i128,
+        min_total_stake: 1i128,
+        initial_liquidity: 0i128,
+        required_resolutions: 1u32,
+        private: false,
+        whitelist_key: None,
+        outcome_descriptions: soroban_sdk::vec![
+            &env,
+            String::from_str(&env, "Yes"),
+            String::from_str(&env, "No"),
+        ],
+    };
+
+    client.create_pool(
+        &creator,
+        &100000u64,
+        &token_address,
+        &2u32,
+        &CATEGORY_TECH,
+        &pool_config,
+    );
+    client.create_pool(
+        &creator,
+        &100500u64,
+        &token_address,
+        &2u32,
+        &CATEGORY_SPORTS,
+        &pool_config,
+    );
+
+    client.set_fee_bps(&admin, &250u32);
+    client.set_treasury(&admin, &treasury);
+    client.set_resolution_delay(&admin, &60u64);
+    client.set_min_pool_duration(&admin, &7200u64);
+    client.set_min_stake(&admin, &5i128);
+    client.set_max_predictions_per_user(&admin, &3u32);
+    client.set_referral_cut_bps(&admin, &2000u32);
+    client.pause(&admin);
+
+    let info = client.get_contract_info();
+    assert_eq!(info.version, 1u32);
+    assert_eq!(info.current_admin, admin);
+    assert!(info.is_paused);
+    assert_eq!(info.total_pools, 2u64);
+    assert_eq!(info.fee_bps, 250u32);
+    assert_eq!(info.referral_cut_bps, 2000u32);
+    assert_eq!(info.treasury, treasury);
+    assert_eq!(info.access_control, ac_client.address);
+    assert_eq!(info.resolution_delay, 60u64);
+    assert_eq!(info.min_pool_duration, 7200u64);
+    assert_eq!(info.min_stake, 5i128);
+    assert_eq!(info.max_predictions_per_user, 3u32);
 }
 
 #[test]


### PR DESCRIPTION
Closes #555
Closes #553
CLoses #552

## Summary
Adds an aggregated `get_contract_info` getter so frontend can fetch protocol metadata and core stats in one call.


## Testing
- Added unit test coverage for `get_contract_info`.
- `cargo test` could not run in this environment because MSVC linker (`link.exe`) is missing.
