### PR TITLE
Dynamic referral rate, active pools API, user prediction history, and pool creation indexer

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,7 +23,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "postgres",
+    "chrono",
 ] }
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -16,6 +16,135 @@ pub fn create_pool(config: &Config) -> Result<PgPool, sqlx::Error> {
         .connect_lazy(&config.database_url)
 }
 
+/// A single row returned by the user prediction history query.
+#[derive(Debug, serde::Serialize, sqlx::FromRow)]
+pub struct PredictionHistoryRow {
+    pub pool_id: i64,
+    pub pool_name: String,
+    pub pool_result: Option<String>,
+    pub outcome: i32,
+    pub amount: i64,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Fetch paginated prediction history for a given user address.
+///
+/// Joins the `predictions` table with the `pools` table to include the pool
+/// name and result alongside each bet.
+pub async fn get_user_prediction_history(
+    pool: &PgPool,
+    address: &str,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<PredictionHistoryRow>, sqlx::Error> {
+    sqlx::query_as!(
+        PredictionHistoryRow,
+        r#"
+        SELECT
+            p.pool_id,
+            pl.name   AS pool_name,
+            pl.result AS pool_result,
+            p.outcome,
+            p.amount,
+            p.created_at
+        FROM predictions p
+        JOIN pools pl ON pl.pool_id = p.pool_id
+        WHERE p.user_address = $1
+        ORDER BY p.created_at DESC
+        LIMIT $2 OFFSET $3
+        "#,
+        address,
+        limit,
+        offset
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// A single row returned by the active pools query.
+#[derive(Debug, serde::Serialize, sqlx::FromRow)]
+pub struct PoolRow {
+    pub pool_id: i64,
+    pub name: String,
+    pub category: String,
+    pub total_stake: i64,
+    pub end_time: chrono::DateTime<chrono::Utc>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Fetch active pools with optional category filter and sort order.
+///
+/// `sort_by` accepts `"popular"`, `"ending_soon"`, or `"new"`.
+pub async fn get_active_pools(
+    pool: &PgPool,
+    sort_by: &str,
+    category: Option<&str>,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<PoolRow>, sqlx::Error> {
+    // Build ORDER BY clause from sort_by parameter.
+    let order_clause = match sort_by {
+        "popular" => "total_stake DESC",
+        "ending_soon" => "end_time ASC",
+        _ => "created_at DESC", // "new" and default
+    };
+
+    // sqlx doesn't support dynamic ORDER BY via bind params, so we build the
+    // query string manually. The order_clause is constructed from a controlled
+    // match arm — no user input reaches it directly.
+    let sql = format!(
+        r#"
+        SELECT pool_id, name, category, total_stake, end_time, created_at
+        FROM pools
+        WHERE state = 'active'
+          AND ($1::text IS NULL OR category = $1)
+        ORDER BY {order_clause}
+        LIMIT $2 OFFSET $3
+        "#
+    );
+
+    sqlx::query_as::<_, PoolRow>(&sql)
+        .bind(category)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await
+}
+
+/// Insert a new pool record decoded from a `PoolCreated` contract event.
+pub async fn insert_pool_from_event(
+    pool: &PgPool,
+    event: &PoolCreatedEvent,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        INSERT INTO pools (pool_id, name, category, total_stake, end_time, state, creator, token, created_at)
+        VALUES ($1, $2, $3, 0, to_timestamp($4), 'active', $5, $6, NOW())
+        ON CONFLICT (pool_id) DO NOTHING
+        "#,
+        event.pool_id as i64,
+        event.description,
+        event.category,
+        event.end_time as f64,
+        event.creator,
+        event.token,
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Decoded data from a `pool_created` contract event.
+#[derive(Debug)]
+pub struct PoolCreatedEvent {
+    pub pool_id: u64,
+    pub creator: String,
+    pub end_time: u64,
+    pub token: String,
+    pub category: String,
+    pub description: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -73,6 +73,16 @@ pub fn build_router(config: Config) -> Router {
         .layer(LoggingLayer)
 }
 
+/// Build the Axum router with a live database pool wired in.
+pub fn build_router_with_db(config: Config, db: sqlx::PgPool) -> Router {
+    Router::new()
+        .route("/", get(root))
+        .route("/health", get(health))
+        .nest("/api", routes::router_with_db(config, db))
+        .layer(build_cors())
+        .layer(LoggingLayer)
+}
+
 #[tokio::main]
 async fn main() {
     dotenvy::dotenv().ok();
@@ -88,12 +98,12 @@ async fn main() {
         .compact()
         .init();
 
-    let _pool = db::create_pool(&config).unwrap_or_else(|error| {
+    let pool = db::create_pool(&config).unwrap_or_else(|error| {
         error!(error = %error, "failed to initialize PostgreSQL pool");
         std::process::exit(1);
     });
 
-    let app = build_router(config.clone());
+    let app = build_router_with_db(config.clone(), pool);
 
     let bind_addr = config.bind_address();
 

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -1,12 +1,15 @@
 use crate::config::Config;
 use axum::Router;
+use sqlx::PgPool;
 
 pub mod v1;
 
-/// Build the API router tree.
-///
-/// Versioned sub-routers make it easier to grow the API without restructuring
-/// the top-level application router.
+/// Build the API router tree (no DB — used in tests).
 pub fn router(config: Config) -> Router {
     Router::new().nest("/v1", v1::router(config))
+}
+
+/// Build the API router tree with a live database pool.
+pub fn router_with_db(config: Config, db: PgPool) -> Router {
+    Router::new().nest("/v1", v1::router_with_db(config, db))
 }

--- a/backend/src/routes/v1.rs
+++ b/backend/src/routes/v1.rs
@@ -1,8 +1,16 @@
-use axum::{extract::State, routing::get, Json, Router};
+use axum::{
+    extract::{Path, Query, State},
+    routing::{get, post},
+    Json, Router,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use sqlx::PgPool;
 
-use crate::config::Config;
+use crate::{
+    config::Config,
+    db::{self, PoolCreatedEvent},
+};
 
 /// Struct representing fee information, matching the contract structure.
 #[derive(Debug, Serialize, Deserialize)]
@@ -11,6 +19,13 @@ pub struct FeeInfo {
     pub treasury_fee_bps: u32,
     /// Referral share of the protocol fee in basis points.
     pub referral_fee_bps: u32,
+}
+
+/// Combined app state: config + optional DB pool.
+#[derive(Clone)]
+pub struct AppState {
+    pub config: Config,
+    pub db: Option<PgPool>,
 }
 
 /// `GET /api/v1/health` health-check endpoint.
@@ -27,18 +42,146 @@ async fn index() -> Json<serde_json::Value> {
 }
 
 /// `GET /api/v1/fees` returns the current fee configuration.
-pub async fn get_fees(State(config): State<Config>) -> Json<FeeInfo> {
+pub async fn get_fees(State(state): State<AppState>) -> Json<FeeInfo> {
     Json(FeeInfo {
-        treasury_fee_bps: config.treasury_fee_bps,
-        referral_fee_bps: config.referral_fee_bps,
+        treasury_fee_bps: state.config.treasury_fee_bps,
+        referral_fee_bps: state.config.referral_fee_bps,
     })
+}
+
+// ── Task 2: Active Pools API ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct PoolsQuery {
+    /// Sort order: "popular" | "ending_soon" | "new" (default)
+    pub sort_by: Option<String>,
+    /// Category filter, e.g. "Sports", "Crypto"
+    pub category: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+/// `GET /api/v1/pools` — list active pools with sorting and category filter.
+pub async fn get_pools(
+    State(state): State<AppState>,
+    Query(params): Query<PoolsQuery>,
+) -> Json<serde_json::Value> {
+    let sort_by = params.sort_by.as_deref().unwrap_or("new");
+    let category = params.category.as_deref();
+    let limit = params.limit.unwrap_or(20).min(100);
+    let offset = params.offset.unwrap_or(0);
+
+    let Some(db) = &state.db else {
+        return Json(json!({ "error": "database not available" }));
+    };
+
+    match db::get_active_pools(db, sort_by, category, limit, offset).await {
+        Ok(pools) => Json(json!({ "pools": pools, "limit": limit, "offset": offset })),
+        Err(e) => Json(json!({ "error": e.to_string() })),
+    }
+}
+
+// ── Task 3: User Prediction History API ──────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct PaginationQuery {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+/// `GET /api/v1/users/:address/history` — paginated prediction history for a user.
+pub async fn get_user_history(
+    State(state): State<AppState>,
+    Path(address): Path<String>,
+    Query(params): Query<PaginationQuery>,
+) -> Json<serde_json::Value> {
+    let limit = params.limit.unwrap_or(20).min(100);
+    let offset = params.offset.unwrap_or(0);
+
+    let Some(db) = &state.db else {
+        return Json(json!({ "error": "database not available" }));
+    };
+
+    match db::get_user_prediction_history(db, &address, limit, offset).await {
+        Ok(rows) => Json(json!({
+            "address": address,
+            "predictions": rows,
+            "limit": limit,
+            "offset": offset,
+        })),
+        Err(e) => Json(json!({ "error": e.to_string() })),
+    }
+}
+
+// ── Task 4: Pool Creation Indexer ─────────────────────────────────────────────
+
+/// Request body for the pool-created event webhook / indexer endpoint.
+///
+/// The event listener decodes the XDR `pool_created` event from the Stellar
+/// Horizon event stream and POSTs the decoded fields here.
+#[derive(Debug, Deserialize)]
+pub struct PoolCreatedPayload {
+    pub pool_id: u64,
+    pub creator: String,
+    pub end_time: u64,
+    pub token: String,
+    pub category: String,
+    /// Pool description / name decoded from the event data.
+    pub description: String,
+}
+
+/// `POST /api/v1/indexer/pool-created` — ingest a decoded `PoolCreated` event
+/// and persist the new pool to the database.
+pub async fn ingest_pool_created(
+    State(state): State<AppState>,
+    Json(payload): Json<PoolCreatedPayload>,
+) -> Json<serde_json::Value> {
+    let Some(db) = &state.db else {
+        return Json(json!({ "error": "database not available" }));
+    };
+
+    let event = PoolCreatedEvent {
+        pool_id: payload.pool_id,
+        creator: payload.creator,
+        end_time: payload.end_time,
+        token: payload.token,
+        category: payload.category,
+        description: payload.description,
+    };
+
+    match db::insert_pool_from_event(db, &event).await {
+        Ok(()) => Json(json!({ "status": "ok", "pool_id": event.pool_id })),
+        Err(e) => Json(json!({ "error": e.to_string() })),
+    }
 }
 
 /// Build the version 1 API router.
 pub fn router(config: Config) -> Router {
+    let state = AppState { config, db: None };
+
     Router::new()
         .route("/", get(index))
         .route("/health", get(health))
         .route("/fees", get(get_fees))
-        .with_state(config)
+        .route("/pools", get(get_pools))
+        .route("/users/{address}/history", get(get_user_history))
+        .route("/indexer/pool-created", post(ingest_pool_created))
+        .with_state(state)
+}
+
+/// Build the version 1 API router with a live database pool.
+pub fn router_with_db(config: Config, db: PgPool) -> Router {
+    let state = AppState {
+        config,
+        db: Some(db),
+    };
+
+    Router::new()
+        .route("/", get(index))
+        .route("/health", get(health))
+        .route("/fees", get(get_fees))
+        .route("/pools", get(get_pools))
+        .route("/users/{address}/history", get(get_user_history))
+        .route("/indexer/pool-created", post(ingest_pool_created))
+        .with_state(state)
 }

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -355,6 +355,7 @@ pub struct PoolStats {
 /// # Invariants
 /// - `fee_bps` must be <= 10,000 (100%) (INV-6)
 /// - `max_predictions_per_user` must be >= 0 (0 = no limit)
+/// - `referral_bps` must be <= 10,000 (100%)
 #[contracttype]
 #[derive(Clone)]
 pub struct Config {
@@ -375,6 +376,10 @@ pub struct Config {
     /// Maximum number of predictions a user can place per pool.
     /// A value of 0 means no limit.
     pub max_predictions_per_user: u32,
+    /// Referral reward rate in basis points (1 bp = 0.01%). Valid range: 0-10,000.
+    /// Represents the share of the protocol fee paid to referrers.
+    /// Default: 500 (5%). Can be raised to 1000 (10%) for referral seasons.
+    pub referral_bps: u32,
 }
 
 /// Fee percentages returned by [`PredifiContract::get_fees`].
@@ -1211,7 +1216,19 @@ impl PredifiContract {
     }
 
     /// Referral cut in basis points (e.g. 5000 = 50% of referrer's fee share to referrer). Default 5000.
+    ///
+    /// Prefers `Config.referral_bps` (set via `set_referral_rate`) when non-zero,
+    /// then falls back to the legacy `ReferralCutBps` storage key, then to 5000.
     fn read_referral_cut_bps(env: &Env) -> u32 {
+        // Prefer the value stored in Config (set via set_referral_rate).
+        let config_bps: Option<Config> = env.storage().instance().get(&DataKey::Config);
+        if let Some(cfg) = config_bps {
+            if cfg.referral_bps > 0 {
+                Self::extend_instance(env);
+                return cfg.referral_bps;
+            }
+        }
+        // Fall back to legacy standalone key.
         let bps = env
             .storage()
             .instance()
@@ -1350,6 +1367,7 @@ impl PredifiContract {
                 min_pool_duration,
                 min_stake: DEFAULT_GLOBAL_MIN_STAKE,
                 max_predictions_per_user,
+                referral_bps: 500, // default 5%
             };
             env.storage().instance().set(&DataKey::Config, &config);
             env.storage().instance().set(&DataKey::PoolIdCtr, &0u64);
@@ -1567,6 +1585,28 @@ impl PredifiContract {
         env.storage()
             .instance()
             .set(&DataKey::ReferralCutBps, &referral_cut_bps);
+        Self::extend_instance(&env);
+        Ok(())
+    }
+
+    /// Set the referral reward rate in basis points stored in the Config struct.
+    ///
+    /// This allows admins to run "referral seasons" (e.g. raise from 500 bps / 5%
+    /// to 1000 bps / 10%) without any code changes.  The value is persisted in the
+    /// `Config` instance-storage entry so it is picked up automatically by fee
+    /// calculation logic.
+    ///
+    /// Caller must hold the Admin role. `bps` must be ≤ 10_000.
+    pub fn set_referral_rate(env: Env, admin: Address, bps: u32) -> Result<(), PredifiError> {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+        Self::require_admin_role(&env, &admin, "set_referral_rate")?;
+        if bps > 10_000 {
+            return Err(PredifiError::InvalidFeeBps);
+        }
+        let mut config = Self::get_config(&env);
+        config.referral_bps = bps;
+        env.storage().instance().set(&DataKey::Config, &config);
         Self::extend_instance(&env);
         Ok(())
     }


### PR DESCRIPTION
closes #556 
closes  #557 
closes #558 
closes #559 

**PR Description:**

This PR ships four independent features across the smart contract and backend.

**Contract — Dynamic Referral Reward Rate**

Adds a `referral_bps` field to the `Config` storage struct so the referral reward rate is persisted on-chain alongside the rest of the protocol configuration. A new `set_referral_rate(env, admin, bps)` function lets any admin adjust the rate without a contract upgrade — enabling "referral seasons" (e.g. bumping from the default 5% to 10%) purely through a governance call. The `read_referral_cut_bps` helper is updated to prefer `Config.referral_bps` when non-zero, falling back to the legacy `ReferralCutBps` storage key for backward compatibility. The default is initialized to 500 bps (5%) at contract init.

**Backend — Active Pools API (`GET /api/v1/pools`)**

New endpoint that returns pools currently in the `active` state. Supports:
- `sort_by=popular` — orders by `total_stake DESC` for the landing page "most money" view
- `sort_by=ending_soon` — orders by `end_time ASC` for the "about to end" view
- `sort_by=new` (default) — orders by `created_at DESC`
- `?category=Sports` (or any category) — filters by pool category
- `limit` / `offset` pagination

**Backend — User Prediction History API (`GET /api/v1/users/:address/history`)**

New endpoint for the user profile page. Returns every prediction a user has ever placed, joined with the `pools` table to include the pool name and result alongside each bet. Supports `limit` and `offset` query params for pagination. The database query lives in `db.rs` and the route handler in `routes/v1.rs`.

**Backend — Pool Creation Indexer (`POST /api/v1/indexer/pool-created`)**

New internal endpoint that acts as the ingestion point for the off-chain event listener. When the Stellar Horizon event stream emits a `pool_created` contract event, the listener decodes the XDR payload into a `PoolCreatedEvent` struct and POSTs it here. The handler calls `db::insert_pool_from_event` which does an `INSERT ... ON CONFLICT DO NOTHING` into the `pools` table, making the pool immediately queryable via the pools API.

Also wires the live `PgPool` into the router state (`AppState`) so all DB-backed handlers share a single connection pool, while the test router path keeps `db: None` to stay dependency-free.