### PR TITLE
feat: response wrapper, batch claims, price cache, referral API

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -24,6 +24,7 @@ sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "postgres",
 ] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/backend/migrations/001_create_referrals.sql
+++ b/backend/migrations/001_create_referrals.sql
@@ -1,0 +1,15 @@
+-- Migration: create referrals table
+--
+-- Tracks on-chain referral events indexed off-chain by the backend.
+-- Each row represents one referral: a user who staked in a pool via a referrer link.
+
+CREATE TABLE IF NOT EXISTS referrals (
+    id            BIGSERIAL    PRIMARY KEY,
+    referrer      TEXT         NOT NULL,          -- referrer wallet address
+    user_address  TEXT         NOT NULL,          -- referred user wallet address
+    pool_id       BIGINT       NOT NULL,          -- prediction pool ID
+    amount        BIGINT       NOT NULL DEFAULT 0, -- stake amount in stroops/base units
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_referrals_referrer ON referrals (referrer);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,7 +4,10 @@
 
 pub mod config;
 pub mod db;
+pub mod price_cache;
+pub mod referrals;
 pub mod request_logger;
+pub mod response;
 pub mod routes;
 
 use axum::{routing::get, Json, Router};
@@ -64,11 +67,25 @@ async fn root() -> Json<serde_json::Value> {
 }
 
 /// Build the Axum router with CORS and logging middleware attached.
-pub fn build_router(config: Config) -> Router {
+pub fn build_router(config: Config, cache: price_cache::PriceCache) -> Router {
     Router::new()
         .route("/", get(root))
         .route("/health", get(health))
-        .nest("/api", routes::router(config))
+        .nest("/api", routes::router(config, cache, None))
+        .layer(build_cors())
+        .layer(LoggingLayer)
+}
+
+/// Build the Axum router with a live database pool.
+pub fn build_router_with_db(
+    config: Config,
+    cache: price_cache::PriceCache,
+    pool: sqlx::PgPool,
+) -> Router {
+    Router::new()
+        .route("/", get(root))
+        .route("/health", get(health))
+        .nest("/api", routes::router(config, cache, Some(pool)))
         .layer(build_cors())
         .layer(LoggingLayer)
 }
@@ -88,12 +105,15 @@ async fn main() {
         .compact()
         .init();
 
-    let _pool = db::create_pool(&config).unwrap_or_else(|error| {
+    let pool = db::create_pool(&config).unwrap_or_else(|error| {
         error!(error = %error, "failed to initialize PostgreSQL pool");
         std::process::exit(1);
     });
 
-    let app = build_router(config.clone());
+    let cache = price_cache::PriceCache::new();
+    price_cache::spawn_fetcher(cache.clone());
+
+    let app = build_router_with_db(config.clone(), cache, pool);
 
     let bind_addr = config.bind_address();
 

--- a/backend/src/price_cache.rs
+++ b/backend/src/price_cache.rs
@@ -1,0 +1,237 @@
+//! # Oracle Price Cache Service
+//!
+//! Fetches current prices for BTC, ETH, and XLM from CoinGecko every 60 seconds
+//! and stores them in a shared in-memory cache so the frontend can read them
+//! without hitting the blockchain or an external API on every request.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! // In main / router setup:
+//! let cache = price_cache::PriceCache::new();
+//! price_cache::spawn_fetcher(cache.clone());
+//!
+//! // In the Axum router:
+//! Router::new()
+//!     .route("/api/v1/prices", get(price_cache::get_prices))
+//!     .with_state(cache)
+//! ```
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use axum::{extract::State, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info};
+
+use crate::response::ApiResponse;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// A single asset price entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetPrice {
+    /// Asset symbol, e.g. `"BTC"`.
+    pub symbol: String,
+    /// Price in USD.
+    pub price_usd: f64,
+}
+
+/// Shared, thread-safe price cache.
+#[derive(Clone, Default)]
+pub struct PriceCache(Arc<RwLock<HashMap<String, f64>>>);
+
+impl PriceCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Overwrite the cache with a fresh snapshot.
+    pub fn update(&self, prices: HashMap<String, f64>) {
+        if let Ok(mut guard) = self.0.write() {
+            *guard = prices;
+        }
+    }
+
+    /// Read a snapshot of all cached prices.
+    pub fn snapshot(&self) -> HashMap<String, f64> {
+        self.0.read().map(|g| g.clone()).unwrap_or_default()
+    }
+}
+
+// ── Background fetcher ───────────────────────────────────────────────────────
+
+/// CoinGecko IDs for the assets we track.
+const ASSETS: &[(&str, &str)] = &[
+    ("BTC", "bitcoin"),
+    ("ETH", "ethereum"),
+    ("XLM", "stellar"),
+];
+
+/// Spawn a background task that refreshes the cache every 60 seconds.
+pub fn spawn_fetcher(cache: PriceCache) {
+    tokio::spawn(async move {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .expect("failed to build reqwest client");
+
+        loop {
+            match fetch_prices(&client).await {
+                Ok(prices) => {
+                    info!(assets = prices.len(), "price cache refreshed");
+                    cache.update(prices);
+                }
+                Err(err) => {
+                    error!(error = %err, "price fetch failed; retaining stale cache");
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        }
+    });
+}
+
+/// Fetch prices from CoinGecko simple/price endpoint.
+async fn fetch_prices(client: &reqwest::Client) -> Result<HashMap<String, f64>, reqwest::Error> {
+    let ids: Vec<&str> = ASSETS.iter().map(|(_, id)| *id).collect();
+    let ids_param = ids.join(",");
+
+    let url = format!(
+        "https://api.coingecko.com/api/v3/simple/price?ids={}&vs_currencies=usd",
+        ids_param
+    );
+
+    // Response shape: { "bitcoin": { "usd": 60000.0 }, ... }
+    let raw: HashMap<String, HashMap<String, f64>> = client.get(&url).send().await?.json().await?;
+
+    let mut result = HashMap::new();
+    for (symbol, coingecko_id) in ASSETS {
+        if let Some(inner) = raw.get(*coingecko_id) {
+            if let Some(&price) = inner.get("usd") {
+                result.insert(symbol.to_string(), price);
+            }
+        }
+    }
+    Ok(result)
+}
+
+// ── HTTP handler ─────────────────────────────────────────────────────────────
+
+/// `GET /api/v1/prices`
+///
+/// Returns the latest cached prices for BTC, ETH, and XLM.
+/// Responds with 503 if the cache has not been populated yet.
+pub async fn get_prices(
+    State(cache): State<PriceCache>,
+) -> (StatusCode, Json<ApiResponse<Vec<AssetPrice>>>) {
+    let snapshot = cache.snapshot();
+    if snapshot.is_empty() {
+        return ApiResponse::error(StatusCode::SERVICE_UNAVAILABLE, "price cache not ready");
+    }
+
+    let mut prices: Vec<AssetPrice> = snapshot
+        .into_iter()
+        .map(|(symbol, price_usd)| AssetPrice { symbol, price_usd })
+        .collect();
+    // Stable ordering for deterministic responses
+    prices.sort_by(|a, b| a.symbol.cmp(&b.symbol));
+
+    ApiResponse::success(prices)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_starts_empty() {
+        let cache = PriceCache::new();
+        assert!(cache.snapshot().is_empty());
+    }
+
+    #[test]
+    fn cache_update_and_read() {
+        let cache = PriceCache::new();
+        let mut prices = HashMap::new();
+        prices.insert("BTC".to_string(), 60_000.0);
+        prices.insert("ETH".to_string(), 3_000.0);
+        cache.update(prices);
+
+        let snap = cache.snapshot();
+        assert_eq!(snap.get("BTC"), Some(&60_000.0));
+        assert_eq!(snap.get("ETH"), Some(&3_000.0));
+    }
+
+    #[test]
+    fn cache_clone_shares_state() {
+        let cache = PriceCache::new();
+        let clone = cache.clone();
+
+        let mut prices = HashMap::new();
+        prices.insert("XLM".to_string(), 0.12);
+        cache.update(prices);
+
+        assert_eq!(clone.snapshot().get("XLM"), Some(&0.12));
+    }
+
+    #[tokio::test]
+    async fn get_prices_returns_503_when_empty() {
+        use axum::{body::Body, http::Request};
+        use http_body_util::BodyExt;
+        use tower::ServiceExt;
+
+        let cache = PriceCache::new();
+        let app = axum::Router::new()
+            .route("/prices", axum::routing::get(get_prices))
+            .with_state(cache);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/prices")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn get_prices_returns_200_when_populated() {
+        use axum::{body::Body, http::Request};
+        use http_body_util::BodyExt;
+        use tower::ServiceExt;
+
+        let cache = PriceCache::new();
+        let mut prices = HashMap::new();
+        prices.insert("BTC".to_string(), 50_000.0);
+        cache.update(prices);
+
+        let app = axum::Router::new()
+            .route("/prices", axum::routing::get(get_prices))
+            .with_state(cache);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/prices")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("BTC"));
+        assert!(text.contains("50000"));
+    }
+}

--- a/backend/src/referrals.rs
+++ b/backend/src/referrals.rs
@@ -1,0 +1,96 @@
+//! # Referral Tracking API
+//!
+//! Exposes `GET /api/v1/referrals/:address` for the influencer dashboard.
+//!
+//! ## Expected table schema
+//!
+//! ```sql
+//! CREATE TABLE IF NOT EXISTS referrals (
+//!     id            BIGSERIAL PRIMARY KEY,
+//!     referrer      TEXT      NOT NULL,
+//!     user_address  TEXT      NOT NULL,
+//!     pool_id       BIGINT    NOT NULL,
+//!     amount        BIGINT    NOT NULL DEFAULT 0,
+//!     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+//! );
+//! CREATE INDEX IF NOT EXISTS idx_referrals_referrer ON referrals (referrer);
+//! ```
+//!
+//! ## Response
+//!
+//! ```json
+//! {
+//!   "status": "success",
+//!   "data": {
+//!     "referrer": "GABC...",
+//!     "total_volume": 12500,
+//!     "unique_users": 7
+//!   }
+//! }
+//! ```
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::Serialize;
+use sqlx::PgPool;
+
+use crate::response::ApiResponse;
+
+/// Summary statistics for a single referrer address.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct ReferralStats {
+    /// The queried referrer address.
+    #[sqlx(skip)]
+    pub referrer: String,
+    /// Sum of `amount` across all rows where `referrer = :address`.
+    pub total_volume: i64,
+    /// Count of distinct `user_address` values referred by this address.
+    pub unique_users: i64,
+}
+
+/// `GET /api/v1/referrals/:address`
+///
+/// Returns aggregated referral statistics for the given referrer address.
+/// Responds with 404 if the address has no referral records.
+pub async fn get_referrals(
+    Path(address): Path<String>,
+    State(pool): State<PgPool>,
+) -> (StatusCode, Json<ApiResponse<ReferralStats>>) {
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        total_volume: i64,
+        unique_users: i64,
+    }
+
+    let result = sqlx::query_as::<_, Row>(
+        r#"
+        SELECT
+            COALESCE(SUM(amount), 0)::BIGINT   AS total_volume,
+            COUNT(DISTINCT user_address)::BIGINT AS unique_users
+        FROM referrals
+        WHERE referrer = $1
+        "#,
+    )
+    .bind(&address)
+    .fetch_one(&pool)
+    .await;
+
+    match result {
+        Ok(row) if row.unique_users == 0 => ApiResponse::error(
+            StatusCode::NOT_FOUND,
+            format!("no referrals found for {address}"),
+        ),
+        Ok(row) => ApiResponse::success(ReferralStats {
+            referrer: address,
+            total_volume: row.total_volume,
+            unique_users: row.unique_users,
+        }),
+        Err(err) => {
+            tracing::error!(error = %err, "referrals query failed");
+            ApiResponse::error(StatusCode::INTERNAL_SERVER_ERROR, "database error")
+        }
+    }
+}

--- a/backend/src/response.rs
+++ b/backend/src/response.rs
@@ -1,0 +1,143 @@
+//! # API Response Wrapper
+//!
+//! Provides a generic JSON envelope for all API responses.
+//!
+//! Every response has the same top-level shape:
+//!
+//! ```json
+//! // success
+//! { "status": "success", "data": <T> }
+//!
+//! // error
+//! { "status": "error", "error": "<message>" }
+//! ```
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use crate::response::ApiResponse;
+//!
+//! // success
+//! ApiResponse::success(my_data)
+//!
+//! // error
+//! ApiResponse::<()>::error("not found")
+//! ```
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+
+/// Generic JSON envelope returned by every API handler.
+#[derive(Debug, Serialize)]
+pub struct ApiResponse<T: Serialize> {
+    /// `"success"` or `"error"`.
+    pub status: &'static str,
+    /// Present on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<T>,
+    /// Present on error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl<T: Serialize> ApiResponse<T> {
+    /// Wrap a successful payload.
+    pub fn success(data: T) -> (StatusCode, Json<Self>) {
+        (
+            StatusCode::OK,
+            Json(Self {
+                status: "success",
+                data: Some(data),
+                error: None,
+            }),
+        )
+    }
+
+    /// Wrap an error message with an explicit HTTP status code.
+    pub fn error(status_code: StatusCode, message: impl Into<String>) -> (StatusCode, Json<Self>) {
+        (
+            status_code,
+            Json(Self {
+                status: "error",
+                data: None,
+                error: Some(message.into()),
+            }),
+        )
+    }
+}
+
+impl<T: Serialize + Send> IntoResponse for ApiResponse<T> {
+    fn into_response(self) -> Response {
+        let code = if self.error.is_some() {
+            StatusCode::INTERNAL_SERVER_ERROR
+        } else {
+            StatusCode::OK
+        };
+        (code, Json(self)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn to_value<T: Serialize>(r: &ApiResponse<T>) -> Value {
+        serde_json::to_value(r).unwrap()
+    }
+
+    #[test]
+    fn success_sets_status_and_data() {
+        let (code, Json(resp)) = ApiResponse::success(42u32);
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(resp.status, "success");
+        assert_eq!(resp.data, Some(42u32));
+        assert!(resp.error.is_none());
+    }
+
+    #[test]
+    fn error_sets_status_and_message() {
+        let (code, Json(resp)) = ApiResponse::<()>::error(StatusCode::NOT_FOUND, "not found");
+        assert_eq!(code, StatusCode::NOT_FOUND);
+        assert_eq!(resp.status, "error");
+        assert!(resp.data.is_none());
+        assert_eq!(resp.error.as_deref(), Some("not found"));
+    }
+
+    #[test]
+    fn success_serializes_without_error_field() {
+        let (_, Json(resp)) = ApiResponse::success("hello");
+        let v = to_value(&resp);
+        assert!(v.get("error").is_none(), "error field must be absent on success");
+        assert_eq!(v["status"], "success");
+        assert_eq!(v["data"], "hello");
+    }
+
+    #[test]
+    fn error_serializes_without_data_field() {
+        let (_, Json(resp)) = ApiResponse::<()>::error(StatusCode::BAD_REQUEST, "bad input");
+        let v = to_value(&resp);
+        assert!(v.get("data").is_none(), "data field must be absent on error");
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["error"], "bad input");
+    }
+
+    #[test]
+    fn success_works_with_struct_payload() {
+        #[derive(Serialize, PartialEq, Debug)]
+        struct Payload {
+            id: u32,
+            name: String,
+        }
+        let (code, Json(resp)) = ApiResponse::success(Payload {
+            id: 1,
+            name: "pool".into(),
+        });
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(resp.data.unwrap().id, 1);
+    }
+}

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -1,12 +1,10 @@
 use crate::config::Config;
+use crate::price_cache::PriceCache;
 use axum::Router;
 
 pub mod v1;
 
 /// Build the API router tree.
-///
-/// Versioned sub-routers make it easier to grow the API without restructuring
-/// the top-level application router.
-pub fn router(config: Config) -> Router {
-    Router::new().nest("/v1", v1::router(config))
+pub fn router(config: Config, cache: PriceCache, pool: Option<sqlx::PgPool>) -> Router {
+    Router::new().nest("/v1", v1::router(config, cache, pool))
 }

--- a/backend/src/routes/v1.rs
+++ b/backend/src/routes/v1.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::config::Config;
+use crate::price_cache::PriceCache;
 
 /// Struct representing fee information, matching the contract structure.
 #[derive(Debug, Serialize, Deserialize)]
@@ -26,19 +27,75 @@ async fn index() -> Json<serde_json::Value> {
     }))
 }
 
-/// `GET /api/v1/fees` returns the current fee configuration.
-pub async fn get_fees(State(config): State<Config>) -> Json<FeeInfo> {
-    Json(FeeInfo {
-        treasury_fee_bps: config.treasury_fee_bps,
-        referral_fee_bps: config.referral_fee_bps,
-    })
+/// Shared state for all v1 routes.
+#[derive(Clone)]
+pub struct AppState {
+    pub config: Config,
+    pub cache: PriceCache,
+    /// Optional DB pool — absent in unit tests that don't need a database.
+    pub pool: Option<sqlx::PgPool>,
+}
+
+impl axum::extract::FromRef<AppState> for Config {
+    fn from_ref(state: &AppState) -> Self {
+        state.config.clone()
+    }
+}
+
+impl axum::extract::FromRef<AppState> for PriceCache {
+    fn from_ref(state: &AppState) -> Self {
+        state.cache.clone()
+    }
+}
+
+impl axum::extract::FromRef<AppState> for Option<sqlx::PgPool> {
+    fn from_ref(state: &AppState) -> Self {
+        state.pool.clone()
+    }
 }
 
 /// Build the version 1 API router.
-pub fn router(config: Config) -> Router {
+pub fn router(config: Config, cache: PriceCache, pool: Option<sqlx::PgPool>) -> Router {
+    let state = AppState { config, cache, pool };
+
     Router::new()
         .route("/", get(index))
         .route("/health", get(health))
         .route("/fees", get(get_fees))
-        .with_state(config)
+        .route("/prices", get(crate::price_cache::get_prices))
+        .route("/referrals/{address}", get(referrals_handler))
+        .with_state(state)
+}
+
+/// `GET /api/v1/fees` — reads fee config from the shared AppState.
+async fn get_fees(State(state): State<AppState>) -> Json<FeeInfo> {
+    Json(FeeInfo {
+        treasury_fee_bps: state.config.treasury_fee_bps,
+        referral_fee_bps: state.config.referral_fee_bps,
+    })
+}
+
+/// `GET /api/v1/referrals/:address` — delegates to the referrals module.
+///
+/// Requires a live DB pool; returns 503 if the pool is not configured.
+async fn referrals_handler(
+    axum::extract::Path(address): axum::extract::Path<String>,
+    State(state): State<AppState>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    use axum::http::StatusCode;
+    use crate::response::ApiResponse;
+
+    match state.pool {
+        Some(pool) => {
+            let (status, body) =
+                crate::referrals::get_referrals(axum::extract::Path(address), State(pool)).await;
+            (status, body).into_response()
+        }
+        None => ApiResponse::<()>::error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database not configured",
+        )
+        .into_response(),
+    }
 }

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -3,7 +3,7 @@ use http_body_util::BodyExt;
 use tower::ServiceExt; // provides `.oneshot()`
 
 // Pull in the router builder from main.rs.
-use crate::build_router;
+use crate::{build_router, price_cache::PriceCache};
 
 /// Build a bare GET request with no body for the given path.
 fn get(path: &str) -> Request<axum::body::Body> {
@@ -29,7 +29,7 @@ use crate::config::Config;
 /// GET /must return HTTP 200.
 #[tokio::test]
 async fn root_returns_200() {
-    let response = build_router(Config::default_for_test())
+    let response = build_router(Config::default_for_test(), PriceCache::new())
         .oneshot(get("/"))
         .await
         .expect("request failed");
@@ -40,7 +40,7 @@ async fn root_returns_200() {
 /// GET /health must return HTTP 200 with `{"status":"ok"}` in the body.
 #[tokio::test]
 async fn health_returns_200_with_ok_body() {
-    let response = build_router(Config::default_for_test())
+    let response = build_router(Config::default_for_test(), PriceCache::new())
         .oneshot(get("/health"))
         .await
         .expect("request failed");
@@ -57,7 +57,7 @@ async fn health_returns_200_with_ok_body() {
 /// GET /api/v1/health must return HTTP 200 from the nested v1 router.
 #[tokio::test]
 async fn api_v1_health_returns_200_with_versioned_body() {
-    let response = build_router(Config::default_for_test())
+    let response = build_router(Config::default_for_test(), PriceCache::new())
         .oneshot(get("/api/v1/health"))
         .await
         .expect("request failed");
@@ -74,7 +74,7 @@ async fn api_v1_health_returns_200_with_versioned_body() {
 /// GET /api/v1 must return HTTP 200 from the version discovery route.
 #[tokio::test]
 async fn api_v1_index_returns_200() {
-    let response = build_router(Config::default_for_test())
+    let response = build_router(Config::default_for_test(), PriceCache::new())
         .oneshot(get("/api/v1"))
         .await
         .expect("request failed");
@@ -89,7 +89,7 @@ async fn api_v1_fees_returns_config_values() {
     config.treasury_fee_bps = 400;
     config.referral_fee_bps = 6000;
 
-    let response = build_router(config)
+    let response = build_router(config, PriceCache::new())
         .oneshot(get("/api/v1/fees"))
         .await
         .expect("request failed");
@@ -110,7 +110,7 @@ async fn api_v1_fees_returns_config_values() {
 /// GET /nonexistent must return HTTP 404 (Axum's built-in fallback).
 #[tokio::test]
 async fn unknown_route_returns_404() {
-    let response = build_router(Config::default_for_test())
+    let response = build_router(Config::default_for_test(), PriceCache::new())
         .oneshot(get("/nonexistent"))
         .await
         .expect("request failed");
@@ -121,7 +121,7 @@ async fn unknown_route_returns_404() {
 /// Verify the middleware does not alter the status code of a 200 response.
 #[tokio::test]
 async fn middleware_does_not_alter_200_status() {
-    let response = build_router(Config::default_for_test())
+    let response = build_router(Config::default_for_test(), PriceCache::new())
         .oneshot(get("/health"))
         .await
         .expect("request failed");
@@ -136,7 +136,7 @@ async fn middleware_does_not_alter_200_status() {
 /// Verify the middleware does not alter the status code of a 404 response.
 #[tokio::test]
 async fn middleware_does_not_alter_404_status() {
-    let response = build_router(Config::default_for_test())
+    let response = build_router(Config::default_for_test(), PriceCache::new())
         .oneshot(get("/no-such-path"))
         .await
         .expect("request failed");
@@ -159,7 +159,7 @@ async fn middleware_handles_multiple_requests_sequentially() {
     ];
 
     for (path, expected_status) in paths_and_expected {
-        let response = build_router(Config::default_for_test())
+        let response = build_router(Config::default_for_test(), PriceCache::new())
             .oneshot(get(path))
             .await
             .expect("request failed");
@@ -175,7 +175,7 @@ async fn middleware_handles_multiple_requests_sequentially() {
 /// CORS headers must be present when a request comes from an allowed origin.
 #[tokio::test]
 async fn cors_allows_allowed_origin() {
-    let response = build_router(Config::default_for_test())
+    let response = build_router(Config::default_for_test(), PriceCache::new())
         .oneshot(
             Request::builder()
                 .method(Method::GET)
@@ -204,7 +204,7 @@ async fn cors_allows_allowed_origin() {
 /// Preflight OPTIONS request must return 200 for allowed origins.
 #[tokio::test]
 async fn cors_handles_preflight_request() {
-    let response = build_router(Config::default_for_test())
+    let response = build_router(Config::default_for_test(), PriceCache::new())
         .oneshot(
             Request::builder()
                 .method(Method::OPTIONS)

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -2896,6 +2896,35 @@ impl PredifiContract {
         result
     }
 
+    /// Claim winnings from multiple pools in a single transaction.
+    ///
+    /// Iterates over `pool_ids`, calls the single-pool claim logic for each,
+    /// and returns a `Map<u64, i128>` showing how much was claimed per pool.
+    /// Pools that yield 0 (loser, already claimed, no prediction) are still
+    /// included in the map with value 0 so callers can distinguish "processed"
+    /// from "not attempted".
+    ///
+    /// # Arguments
+    /// * `user`     - Address claiming winnings (must provide auth once)
+    /// * `pool_ids` - List of pool IDs to claim from
+    ///
+    /// # Returns
+    /// `Map<u64, i128>` — claimed amount per pool (0 for non-winners / already claimed)
+    pub fn batch_claim_winnings(
+        env: Env,
+        user: Address,
+        pool_ids: Vec<u64>,
+    ) -> soroban_sdk::Map<u64, i128> {
+        user.require_auth();
+        let mut results: soroban_sdk::Map<u64, i128> = soroban_sdk::Map::new(&env);
+        for pool_id in pool_ids.iter() {
+            let amount = Self::claim_winnings(env.clone(), user.clone(), pool_id)
+                .unwrap_or(0);
+            results.set(pool_id, amount);
+        }
+        results
+    }
+
     /// Claim a refund from a canceled pool. Returns the refunded amount.
     /// Only available for canceled pools. User receives their full original stake.
     ///

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -9251,3 +9251,72 @@ fn test_update_pool_description_unauthorized() {
     );
     assert_eq!(result, Err(Ok(PredifiError::Unauthorized)));
 }
+
+#[test]
+fn test_batch_claim_winnings_three_pools() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, token, token_admin_client, _, operator, creator) = setup(&env);
+    let contract_addr = client.address.clone();
+
+    let user = Address::generate(&env);
+    // Mint enough for 3 stakes of 100 each
+    token_admin_client.mint(&user, &300);
+
+    // Helper closure to create a pool and return its id
+    let make_pool = |desc: &str| -> u64 {
+        client.create_pool(
+            &creator,
+            &100_000u64,
+            &token_address,
+            &2u32,
+            &symbol_short!("Sports"),
+            &PoolConfig {
+                description: String::from_str(&env, desc),
+                metadata_url: String::from_str(&env, "ipfs://test"),
+                min_stake: 1i128,
+                max_stake: 0i128,
+                max_total_stake: 0,
+                min_total_stake: 1,
+                initial_liquidity: 0i128,
+                required_resolutions: 1u32,
+                private: false,
+                whitelist_key: None,
+                outcome_descriptions: soroban_sdk::vec![
+                    &env,
+                    String::from_str(&env, "Yes"),
+                    String::from_str(&env, "No"),
+                ],
+            },
+        )
+    };
+
+    let pool_a = make_pool("Pool A");
+    let pool_b = make_pool("Pool B");
+    let pool_c = make_pool("Pool C");
+
+    // User stakes outcome 0 in all three pools
+    client.place_prediction(&user, &pool_a, &100, &0, &None, &None);
+    client.place_prediction(&user, &pool_b, &100, &0, &None, &None);
+    client.place_prediction(&user, &pool_c, &100, &0, &None, &None);
+
+    // Advance time past end_time and resolve all pools with outcome 0 (user wins)
+    env.ledger().with_mut(|li| li.timestamp = 100_001);
+    client.resolve_pool(&operator, &pool_a, &0u32);
+    client.resolve_pool(&operator, &pool_b, &0u32);
+    client.resolve_pool(&operator, &pool_c, &0u32);
+
+    let pool_ids = soroban_sdk::vec![&env, pool_a, pool_b, pool_c];
+    let results = client.batch_claim_winnings(&user, &pool_ids);
+
+    // User was the sole staker on each pool so they get the full stake back
+    assert_eq!(results.get(pool_a).unwrap(), 100);
+    assert_eq!(results.get(pool_b).unwrap(), 100);
+    assert_eq!(results.get(pool_c).unwrap(), 100);
+
+    // Contract should be empty after all claims
+    assert_eq!(token.balance(&contract_addr), 0);
+    // User should have their original 300 back
+    assert_eq!(token.balance(&user), 300);
+}


### PR DESCRIPTION
 closes #491
closes #554
closes #560 
closes #561

PR Description
  
  Summary
  
  This PR implements four independent features across the backend and Soroban contract.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 1 — API Response Wrapper (backend/src/response.rs)
  
  Added a generic ApiResponse<T> envelope that wraps every API response in a consistent JSON shape:
  
  { "status": "success", "data": <T> }
  { "status": "error",   "error": "<message>" }
  
  skip_serializing_if ensures the absent field is never emitted. Includes 5 unit tests covering
  success, error, struct payloads, and serialization shape. Exposed as pub mod response in main.rs.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 2 — Batch Claim Winnings (contract/contracts/predifi-contract/src/lib.rs)
  
  Added batch_claim_winnings(env, user, pool_ids: Vec<u64>) -> Map<u64, i128> to the Soroban
  contract. It requires auth once, iterates the pool list, delegates to the existing claim_winnings
  per pool (preserving all re-entrancy guards and fee logic), and returns a map of pool_id →
  amount_claimed. Errors per pool are swallowed as 0 so a single bad pool doesn't abort the batch.
  
  Added test_batch_claim_winnings_three_pools — user wins in 3 pools, claims all at once, verifies
  per-pool amounts and final token balances.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 3 — Oracle Price Cache Service (backend/src/price_cache.rs)
  
  - PriceCache — Arc<RwLock<HashMap<String, f64>>>, cheaply cloneable shared state.
  - spawn_fetcher(cache) — background tokio::spawn loop that hits CoinGecko's /simple/price endpoint
  every 60 seconds for BTC, ETH, XLM. Logs errors and retains stale data on failure.
  - GET /api/v1/prices — returns sorted [{symbol, price_usd}]; 503 if cache not yet populated.
  - Added reqwest = "0.12" (rustls-tls, json features) to Cargo.toml.
  - Wired into AppState via FromRef so Axum sub-state extraction works cleanly.
  - 4 unit tests (cache state, clone sharing, 503 on empty, 200 when populated).
  
  ───────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 4 — Referral Tracking API (backend/src/referrals.rs)
  
  - GET /api/v1/referrals/:address — queries the referrals table, returns { referrer, total_volume,
  unique_users }.
  - Uses sqlx::query_as (runtime query, no compile-time DB required).
  - Returns 404 if no rows exist for the address, 500 on DB error.
  - Added migrations/001_create_referrals.sql with the table schema and index.
  - Pool is Option<PgPool> in AppState — None in unit tests, Some(pool) in production via
  build_router_with_db.
  
  