### PR TITLE
Fix category validation, treasury withdraw minimum, multi-operator voting, and cancel_pool reentrancy

### DIFF
--- a/contract/contracts/predifi-contract/src/constants.rs
+++ b/contract/contracts/predifi-contract/src/constants.rs
@@ -35,6 +35,10 @@ pub const CANCELATION_DELAY: u64 = 604800;
 /// Predictions below this threshold are rejected to prevent spam.
 pub const DEFAULT_GLOBAL_MIN_STAKE: i128 = 1;
 
+/// Minimum withdrawal amount for treasury withdrawals (1000 units in base token units).
+/// Withdrawals below this threshold are rejected to prevent dust withdrawals and wasted gas.
+pub const MIN_WITHDRAWAL_AMOUNT: i128 = 1000;
+
 /// Maximum number of options/outcomes allowed in a single pool.
 /// This limit prevents excessive gas costs and ensures reasonable pool complexity.
 pub const MAX_OPTIONS_COUNT: u32 = 100;

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -172,6 +172,8 @@ pub enum PredifiError {
     ArithmeticError = 110,
     /// required_resolutions exceeds the number of active operators; pool can never be resolved.
     RequiredResolutionsExceedOperators = 200,
+    /// Invalid data provided (e.g., unrecognized category symbol).
+    InvalidData = 112,
 }
 
 /// Represents the current state of a prediction market.
@@ -971,6 +973,16 @@ pub struct ResolutionConflictEvent {
     pub outcome: u32,
     pub existing_outcome: u32,
 }
+
+#[contractevent(topics = ["resolution_vote_cast"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolutionVoteCastEvent {
+    pub pool_id: u64,
+    pub voter: Address,
+    pub outcome: u32,
+    pub vote_count: u32,
+    pub required_resolutions: u32,
+}
 mod events;
 // pub use events::*; // Unused import
 
@@ -997,10 +1009,11 @@ impl PredifiContract {
     // ====== Pure Helper Functions (side-effect free, verifiable) ======
 
     /// Validate that a category symbol is in the allowed list, falling back to CATEGORY_OTHER if not.
-    /// Canonical categories are defined as constants at the top of the file.
-    /// Any non-matching category is normalized to CATEGORY_OTHER to ensure compatibility
-    /// with off-chain analytics while allowing specialized categories in metadata if needed.
-    fn validate_category(env: &Env, category: &Symbol) -> Symbol {
+    /// Validate category symbol against allowed list.
+    /// Returns the category if valid, otherwise returns InvalidData error.
+    /// PRE: category is a valid Symbol
+    /// POST: returns Ok(category) if category is in the allowed list, else Err(InvalidData)
+    fn validate_category(env: &Env, category: &Symbol) -> Result<Symbol, PredifiError> {
         let mut allowed = Vec::new(env);
         allowed.push_back(CATEGORY_SPORTS);
         allowed.push_back(CATEGORY_FINANCE);
@@ -1013,11 +1026,11 @@ impl PredifiContract {
         for i in 0..allowed.len() {
             if let Some(allowed_cat) = allowed.get(i) {
                 if &allowed_cat == category {
-                    return category.clone();
+                    return Ok(category.clone());
                 }
             }
         }
-        CATEGORY_OTHER
+        Err(PredifiError::InvalidData)
     }
 
     /// Pure: Check if pool state transition is valid
@@ -1820,7 +1833,7 @@ impl PredifiContract {
     /// # Security
     /// - Requires Admin role (0)
     /// - Emits TreasuryWithdrawnEvent for audit trail
-    /// - Validates amount > 0
+    /// - Validates amount >= MIN_WITHDRAWAL_AMOUNT
     /// - Checks contract has sufficient balance
     pub fn withdraw_treasury(
         env: Env,
@@ -1835,8 +1848,8 @@ impl PredifiContract {
         // Verify admin role
         Self::require_admin_role(&env, &admin, "withdraw_treasury")?;
 
-        // Validate amount
-        if amount <= 0 {
+        // Validate amount meets minimum threshold
+        if amount < MIN_WITHDRAWAL_AMOUNT {
             return Err(PredifiError::InvalidAmount);
         }
 
@@ -1844,6 +1857,7 @@ impl PredifiContract {
         let token_client = token::Client::new(&env, &token);
         let contract_balance = token_client.balance(&env.current_contract_address());
 
+        // Verify sufficient balance
         if contract_balance < amount {
             return Err(PredifiError::InsufficientBalance);
         }
@@ -1892,8 +1906,11 @@ impl PredifiContract {
         Self::require_not_paused(&env);
         creator.require_auth();
 
-        // Validate: category must be in the allowed list, else fallback to CATEGORY_OTHER
-        let normalized_category = Self::validate_category(&env, &category);
+        // Validate: category must be in the allowed list, return error if invalid
+        let normalized_category = match Self::validate_category(&env, &category) {
+            Ok(cat) => cat,
+            Err(e) => soroban_sdk::panic_with_error!(&env, e),
+        };
 
         // Validate: token must be on the allowed betting whitelist
         if !Self::is_token_whitelisted(&env, &token) {
@@ -2356,6 +2373,16 @@ impl PredifiContract {
             .set(&outcome_votes_key, &new_outcome_votes);
         Self::extend_persistent(&env, &outcome_votes_key);
 
+        // Emit a ResolutionVoteCastEvent for observability
+        ResolutionVoteCastEvent {
+            pool_id,
+            voter: operator.clone(),
+            outcome,
+            vote_count: new_outcome_votes,
+            required_resolutions: pool.required_resolutions,
+        }
+        .publish(&env);
+
         // Detect conflicts
         if new_total_votes > new_outcome_votes {
             for i in 0..pool.options_count {
@@ -2464,6 +2491,9 @@ impl PredifiContract {
         Self::require_not_paused(&env);
         operator.require_auth();
 
+        // Protect state-modifying external interactions from reentrancy
+        Self::enter_reentrancy_guard(&env);
+
         let pool_key = DataKey::Pool(pool_id);
         let mut pool: Pool = env
             .storage()
@@ -2487,9 +2517,11 @@ impl PredifiContract {
             } else {
                 // Allow creator to cancel only if no bets have been placed beyond initial liquidity
                 if operator != pool.creator {
+                    Self::exit_reentrancy_guard(&env);
                     return Err(PredifiError::Unauthorized);
                 }
                 if pool.total_stake > pool.initial_liquidity {
+                    Self::exit_reentrancy_guard(&env);
                     return Err(PredifiError::Unauthorized);
                 }
             }
@@ -2497,10 +2529,12 @@ impl PredifiContract {
 
         // Ensure resolved pools cannot be canceled
         if pool.state == MarketState::Resolved {
+            Self::exit_reentrancy_guard(&env);
             return Err(PredifiError::PoolNotResolved);
         }
 
         if !Self::is_pool_active(&pool) {
+            Self::exit_reentrancy_guard(&env);
             return Err(PredifiError::InvalidPoolState);
         }
 
@@ -2516,6 +2550,8 @@ impl PredifiContract {
             operator,
         }
         .publish(&env);
+
+        Self::exit_reentrancy_guard(&env);
 
         Ok(())
     }
@@ -3819,6 +3855,16 @@ impl OracleCallback for PredifiContract {
             oracle: oracle.clone(),
             outcome,
             proof,
+        }
+        .publish(&env);
+
+        // Emit vote-cast event for oracle votes as well
+        ResolutionVoteCastEvent {
+            pool_id,
+            voter: oracle.clone(),
+            outcome,
+            vote_count: new_outcome_votes,
+            required_resolutions: pool.required_resolutions,
         }
         .publish(&env);
 


### PR DESCRIPTION
Fixes: Closes #596:  now returns  for unknown categories. Closes #599:  enforces a minimum withdrawal amount and checks balance. Closes  #597: Multi-operator resolution publishes  per vote and finalizes when  reached. Closes #598:  now uses the reentrancy guard.