### PR TITLE
Fix #615: Use sentinel value for unresolved pool outcome

### DIFF
--- a/contract/contracts/predifi-contract/src/constants.rs
+++ b/contract/contracts/predifi-contract/src/constants.rs
@@ -48,6 +48,10 @@ pub const MAX_OPTIONS_COUNT: u32 = 100;
 /// At 7 decimal places (e.g., USDC on Stellar), this equals 100,000,000 USDC.
 pub const MAX_INITIAL_LIQUIDITY: i128 = 100_000_000_000_000;
 
+/// Sentinel value used to indicate that a pool outcome has not been resolved yet.
+/// This allows us to distinguish between "outcome 0 won" and "pool not resolved".
+pub const UNRESOLVED_OUTCOME: u32 = u32::MAX;
+
 // ═══════════════════════════════════════════════════════════════════════════
 // MONITORING & ALERT THRESHOLDS
 // ═══════════════════════════════════════════════════════════════════════════

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -244,7 +244,8 @@ pub struct Pool {
     /// Possible values: `Active` (betting open), `Resolved` (result final), `Canceled` (refunds available).
     pub state: MarketState,
     /// The winning outcome index (0-based) after resolution.
-    /// Only meaningful if `state` is `Resolved`. Default is 0.
+    /// Only meaningful if `state` is `Resolved`. 
+    /// Uses UNRESOLVED_OUTCOME (u32::MAX) as sentinel for "not yet resolved".
     pub outcome: u32,
     /// The contract address of the Stellar token (e.g., USDC) used for all stakes and payouts.
     pub token: Address,
@@ -1927,6 +1928,11 @@ impl PredifiContract {
         Self::get_config(&env).prediction_cooldown_seconds
     }
 
+    /// Returns true if the pool has a properly resolved outcome (not the sentinel value).
+    pub fn is_pool_resolved(&pool: &Pool) -> bool {
+        pool.outcome != UNRESOLVED_OUTCOME
+    }
+
     /// Return an aggregated metadata view of contract config and protocol state.
     pub fn get_contract_info(env: Env) -> ContractInfo {
         let config = Self::get_config(&env);
@@ -2173,7 +2179,7 @@ impl PredifiContract {
         let pool = Pool {
             end_time,
             state: MarketState::Active,
-            outcome: 0,
+            outcome: UNRESOLVED_OUTCOME,
             token: token.clone(),
             total_stake: config.initial_liquidity,
             category: normalized_category,
@@ -2472,6 +2478,18 @@ impl PredifiContract {
                 operator.clone(),
                 outcome,
                 pool.options_count
+            );
+            return Err(PredifiError::InvalidOutcome);
+        }
+
+        // Validate: outcome cannot be the sentinel value
+        if outcome == UNRESOLVED_OUTCOME {
+            log!(
+                &env,
+                "resolve_pool rejected: outcome cannot be sentinel value",
+                pool_id,
+                operator.clone(),
+                outcome
             );
             return Err(PredifiError::InvalidOutcome);
         }
@@ -3028,6 +3046,11 @@ impl PredifiContract {
                 return Ok(prediction.amount);
             }
 
+            // Check if pool is properly resolved
+            if !Self::is_pool_resolved(&pool) {
+                return Err(PredifiError::PoolNotResolved);
+            }
+            
             if prediction.outcome != pool.outcome {
                 return Ok(0);
             }
@@ -3842,6 +3865,29 @@ impl PredifiContract {
             return Err(PredifiError::ResolutionDelayNotMet);
         }
 
+        // Validate: outcome must be within the valid options range
+        if outcome >= pool.options_count {
+            log!(
+                &env,
+                "resolve_pool_from_price rejected: outcome is out of bounds",
+                pool_id,
+                outcome,
+                pool.options_count
+            );
+            return Err(PredifiError::InvalidOutcome);
+        }
+
+        // Validate: outcome cannot be the sentinel value
+        if outcome == UNRESOLVED_OUTCOME {
+            log!(
+                &env,
+                "resolve_pool_from_price rejected: outcome cannot be sentinel value",
+                pool_id,
+                outcome
+            );
+            return Err(PredifiError::InvalidOutcome);
+        }
+
         // Apply resolution
         pool.state = MarketState::Resolved;
         pool.outcome = outcome;
@@ -3980,6 +4026,11 @@ impl OracleCallback for PredifiContract {
 
         // Validate: outcome must be within the valid options range
         if outcome >= pool.options_count {
+            soroban_sdk::panic_with_error!(&env, PredifiError::InvalidOutcome);
+        }
+
+        // Validate: outcome cannot be the sentinel value
+        if outcome == UNRESOLVED_OUTCOME {
             soroban_sdk::panic_with_error!(&env, PredifiError::InvalidOutcome);
         }
 


### PR DESCRIPTION
- Add UNRESOLVED_OUTCOME constant (u32::MAX) to distinguish between unresolved pools and outcome 0 winning
- Update pool creation to initialize outcome with sentinel value
- Add is_pool_resolved() helper function
- Update claim logic to properly check for resolved pools
- Add validation in all resolution functions to prevent setting sentinel outcome
- Update Pool struct documentation

This fixes the ambiguity where pool.outcome = 0 could mean either 'outcome 0 won' or 'pool not resolved'.

# Description

Provide a brief summary of the changes and the motivation behind them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or internal tool improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Screenshots / Recordings

> [!IMPORTANT]
> **A screenshot or screen recording is REQUIRED for all frontend/UI changes.**
> Please paste your screenshots or recordings below.

<!-- Paste screenshots/recordings here -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

closes #615 