### PR TITLE
fix(pagination): guard offset+limit overflow in paginated queries (#616)

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -174,6 +174,8 @@ pub enum PredifiError {
     RequiredResolutionsExceedOperators = 200,
     /// Rate limit exceeded, cooldown active, or suspicious activity detected.
     RateLimitOrSuspiciousActivity = 190,
+    /// The pagination offset + limit combination overflows u32 or is otherwise invalid.
+    InvalidPagination = 92,
 }
 
 /// Represents the current state of a prediction market.
@@ -3293,12 +3295,20 @@ impl PredifiContract {
     }
 
     /// Get a paginated list of a user's predictions.
+    ///
+    /// # Errors
+    /// Returns `PredifiError::InvalidPagination` if `offset + limit` overflows `u32`.
     pub fn get_user_predictions(
         env: Env,
         user: Address,
         offset: u32,
         limit: u32,
-    ) -> Vec<UserPredictionDetail> {
+    ) -> Result<Vec<UserPredictionDetail>, PredifiError> {
+        // Guard against offset + limit wrapping around u32::MAX.
+        let end_check = offset
+            .checked_add(limit)
+            .ok_or(PredifiError::InvalidPagination)?;
+
         let count_key = DataKey::UsrPrdCnt(user.clone());
         let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
         if env.storage().persistent().has(&count_key) {
@@ -3308,10 +3318,10 @@ impl PredifiContract {
         let mut results = Vec::new(&env);
 
         if offset >= count || limit == 0 {
-            return results;
+            return Ok(results);
         }
 
-        let end = core::cmp::min(offset.saturating_add(limit), count);
+        let end = core::cmp::min(end_check, count);
 
         for i in offset..end {
             let index_key = DataKey::UsrPrdIdx(user.clone(), i);
@@ -3348,7 +3358,7 @@ impl PredifiContract {
             });
         }
 
-        results
+        Ok(results)
     }
 
     /// This function is optimized for markets with many outcomes (e.g., 32+ teams).
@@ -3435,7 +3445,20 @@ impl PredifiContract {
     }
 
     /// Get a paginated list of pool IDs by category.
-    pub fn get_pools_by_category(env: Env, category: Symbol, offset: u32, limit: u32) -> Vec<u64> {
+    ///
+    /// # Errors
+    /// Returns `PredifiError::InvalidPagination` if `offset + limit` overflows `u32`.
+    pub fn get_pools_by_category(
+        env: Env,
+        category: Symbol,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<u64>, PredifiError> {
+        // Guard against offset + limit wrapping around u32::MAX.
+        offset
+            .checked_add(limit)
+            .ok_or(PredifiError::InvalidPagination)?;
+
         let count_key = DataKey::CatPoolCt(category.clone());
         let count: u32 = if let Some(c) = env.storage().persistent().get(&count_key) {
             Self::extend_persistent(&env, &count_key);
@@ -3447,7 +3470,7 @@ impl PredifiContract {
         let mut results = Vec::new(&env);
 
         if offset >= count || limit == 0 {
-            return results;
+            return Ok(results);
         }
 
         let start_index = count.saturating_sub(offset).saturating_sub(1);
@@ -3466,7 +3489,7 @@ impl PredifiContract {
             results.push_back(pool_id);
         }
 
-        results
+        Ok(results)
     }
 
     /// Get a paginated list of all currently active pool IDs across all categories.
@@ -3482,7 +3505,18 @@ impl PredifiContract {
     /// # Returns
     /// A `Vec<u64>` of active pool IDs. Returns an empty vec if `offset`
     /// is beyond the current count or `limit` is 0.
-    pub fn get_active_pools(env: Env, offset: u32, limit: u32) -> Vec<u64> {
+    /// # Errors
+    /// Returns `PredifiError::InvalidPagination` if `offset + limit` overflows `u32`.
+    pub fn get_active_pools(
+        env: Env,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<u64>, PredifiError> {
+        // Guard against offset + limit wrapping around u32::MAX.
+        let end_check = offset
+            .checked_add(limit)
+            .ok_or(PredifiError::InvalidPagination)?;
+
         let count: u32 = env
             .storage()
             .instance()
@@ -3491,12 +3525,12 @@ impl PredifiContract {
         let mut results = Vec::new(&env);
 
         if offset >= count || limit == 0 {
-            return results;
+            return Ok(results);
         }
 
         Self::extend_instance(&env);
 
-        let end = core::cmp::min(offset.saturating_add(limit), count);
+        let end = core::cmp::min(end_check, count);
 
         for i in offset..end {
             let slot_key = DataKey::ActivePool(i);
@@ -3506,7 +3540,7 @@ impl PredifiContract {
             }
         }
 
-        results
+        Ok(results)
     }
 
     /// Return the total number of currently active (open) pools.

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -1834,6 +1834,49 @@ fn test_get_user_predictions() {
     assert_eq!(p2.len(), 1);
 }
 
+// ── #616: get_user_predictions overflow guard ─────────────────────────────────
+
+/// Regression: offset + limit overflowing u32::MAX must return InvalidPagination
+/// for get_user_predictions (fix for GitHub issue #616).
+#[test]
+fn test_get_user_predictions_overflow_returns_invalid_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, _, _, _, _, _, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    // u32::MAX + 1 wraps to 0 in unchecked arithmetic — must be caught.
+    let result = client.try_get_user_predictions(&user, &u32::MAX, &1u32);
+    match result {
+        Err(Ok(PredifiError::InvalidPagination)) => {} // expected
+        other => panic!(
+            "expected Err(Ok(InvalidPagination)), got an unexpected variant: is_err={}",
+            other.is_err()
+        ),
+    }
+}
+
+/// Regression: offset = 1, limit = u32::MAX also overflows — must be caught.
+#[test]
+fn test_get_user_predictions_overflow_large_limit_returns_invalid_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, _, _, _, _, _, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    let result = client.try_get_user_predictions(&user, &1u32, &u32::MAX);
+    match result {
+        Err(Ok(PredifiError::InvalidPagination)) => {} // expected
+        other => panic!(
+            "expected Err(Ok(InvalidPagination)), got an unexpected variant: is_err={}",
+            other.is_err()
+        ),
+    }
+}
+
+
 #[test]
 fn test_multi_oracle_resolution() {
     let env = Env::default();
@@ -3729,7 +3772,43 @@ fn test_get_pools_by_category() {
     assert_eq!(empty.len(), 0);
 }
 
-// ================== Treasury withdrawal tests ==================
+// ── #616: Pagination overflow guard ──────────────────────────────────────────
+
+/// Regression: offset + limit overflowing u32::MAX must return InvalidPagination
+/// for get_pools_by_category (fix for GitHub issue #616).
+#[test]
+fn test_get_pools_by_category_overflow_returns_invalid_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, _, _, _, _, _, _) = setup(&env);
+
+    let cat = symbol_short!("Tech");
+    // u32::MAX + 1 wraps to 0 in unchecked arithmetic — must be caught.
+    let result = client.try_get_pools_by_category(&cat, &u32::MAX, &1u32);
+    assert_eq!(
+        result,
+        Err(Ok(PredifiError::InvalidPagination)),
+        "offset=u32::MAX with limit=1 must return InvalidPagination"
+    );
+}
+
+/// Regression: offset = 1, limit = u32::MAX also overflows — must be caught.
+#[test]
+fn test_get_pools_by_category_overflow_large_limit_returns_invalid_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, _, _, _, _, _, _) = setup(&env);
+
+    let cat = symbol_short!("Tech");
+    let result = client.try_get_pools_by_category(&cat, &1u32, &u32::MAX);
+    assert_eq!(
+        result,
+        Err(Ok(PredifiError::InvalidPagination)),
+        "offset=1 with limit=u32::MAX must return InvalidPagination"
+    );
+}
 
 #[test]
 fn test_admin_can_withdraw_treasury() {
@@ -7512,6 +7591,41 @@ fn test_get_active_pools_pagination() {
     // limit=0 always returns empty
     let zero_limit = client.get_active_pools(&0u32, &0u32);
     assert_eq!(zero_limit.len(), 0);
+}
+
+// ── #616: get_active_pools overflow guard ─────────────────────────────────────
+
+/// Regression: offset + limit overflowing u32::MAX must return InvalidPagination
+/// for get_active_pools (fix for GitHub issue #616).
+#[test]
+fn test_get_active_pools_overflow_returns_invalid_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, _, _, _, _, _, _) = setup(&env);
+
+    let result = client.try_get_active_pools(&u32::MAX, &1u32);
+    assert_eq!(
+        result,
+        Err(Ok(PredifiError::InvalidPagination)),
+        "offset=u32::MAX with limit=1 must return InvalidPagination"
+    );
+}
+
+/// Regression: offset = 1, limit = u32::MAX overflows — must be caught.
+#[test]
+fn test_get_active_pools_overflow_large_limit_returns_invalid_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, _, _, _, _, _, _) = setup(&env);
+
+    let result = client.try_get_active_pools(&1u32, &u32::MAX);
+    assert_eq!(
+        result,
+        Err(Ok(PredifiError::InvalidPagination)),
+        "offset=1 with limit=u32::MAX must return InvalidPagination"
+    );
 }
 
 // Swap-and-pop correctness: removing the first pool when three exist.


### PR DESCRIPTION
Closes #616 

## Summary

— pagination parameters `offset: u32` and `limit: u32` could silently overflow when added together, causing wrap-around (release mode) or panic (debug mode).

## Root Cause

Three paginated query functions computed `end = offset + limit` using `saturating_add`, which masks the overflow by clamping to `u32::MAX` instead of returning an error. The `InvalidPagination` error variant already existed in the codebase but was never connected to this guard.

## Changes

### `lib.rs`
- Added `InvalidPagination = 92` to the local `PredifiError` enum (aligns with the canonical code in `predifi-errors`)
- **`get_user_predictions`**: return type changed from `Vec<UserPredictionDetail>` → `Result<Vec<UserPredictionDetail>, PredifiError>`
- **`get_pools_by_category`**: return type changed from `Vec<u64>` → `Result<Vec<u64>, PredifiError>`
- **`get_active_pools`**: return type changed from `Vec<u64>` → `Result<Vec<u64>, PredifiError>`
- All three now use `offset.checked_add(limit).ok_or(PredifiError::InvalidPagination)?` before any other logic

### `test.rs`
- Added 6 new regression tests covering the overflow edge cases for all three functions:
  - `offset = u32::MAX, limit = 1`
  - `offset = 1, limit = u32::MAX`

## Testing

Verified with 6 new regression tests that correctly assert `PredifiError::InvalidPagination` (code 92) is returned when pagination parameters would overflow.

## Breaking Change

The return types of `get_user_predictions`, `get_pools_by_category`, and `get_active_pools` are now `Result<Vec<_>, PredifiError>`. Callers using the generated `try_*` client methods are unaffected. Callers using the non-`try_` methods will panic on `InvalidPagination` (consistent with existing contract error handling).
