### PR TITLE
fix: referrer update, max pool duration, and odds calculation

### DIFF
--- a/contract/contracts/predifi-contract/src/constants.rs
+++ b/contract/contracts/predifi-contract/src/constants.rs
@@ -52,6 +52,10 @@ pub const MAX_INITIAL_LIQUIDITY: i128 = 100_000_000_000_000;
 /// This allows us to distinguish between "outcome 0 won" and "pool not resolved".
 pub const UNRESOLVED_OUTCOME: u32 = u32::MAX;
 
+/// Maximum allowed pool duration in seconds (365 days).
+/// Pools with end_time beyond current_time + MAX_POOL_DURATION are rejected.
+pub const MAX_POOL_DURATION: u64 = 31_536_000;
+
 // ═══════════════════════════════════════════════════════════════════════════
 // MONITORING & ALERT THRESHOLDS
 // ═══════════════════════════════════════════════════════════════════════════

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -176,6 +176,8 @@ pub enum PredifiError {
     RateLimitOrSuspiciousActivity = 190,
     /// The pagination offset + limit combination overflows u32 or is otherwise invalid.
     InvalidPagination = 92,
+    /// The end_time exceeds the maximum allowed pool duration.
+    InvalidTimestamp = 94,
 }
 
 /// Represents the current state of a prediction market.
@@ -1975,6 +1977,41 @@ impl PredifiContract {
         vol
     }
 
+    /// Update or remove the referrer for a (user, pool_id) pair.
+    ///
+    /// Callable only by the user themselves. Allows correcting a mistaken or
+    /// compromised referrer address before or after predictions are placed.
+    ///
+    /// # Arguments
+    /// * `user`         - The user whose referrer is being updated (must provide auth).
+    /// * `pool_id`      - The pool for which the referrer is being updated.
+    /// * `new_referrer` - `Some(address)` to set a new referrer, `None` to remove it.
+    ///
+    /// # Errors
+    /// * `Unauthorized` if the caller is not the user.
+    pub fn update_referrer(
+        env: Env,
+        user: Address,
+        pool_id: u64,
+        new_referrer: Option<Address>,
+    ) -> Result<(), PredifiError> {
+        user.require_auth();
+        let referrer_key = DataKey::Referrer(user.clone(), pool_id);
+        match new_referrer {
+            Some(ref addr) => {
+                if addr == &user {
+                    return Err(PredifiError::Unauthorized);
+                }
+                env.storage().persistent().set(&referrer_key, addr);
+                Self::extend_persistent(&env, &referrer_key);
+            }
+            None => {
+                env.storage().persistent().remove(&referrer_key);
+            }
+        }
+        Ok(())
+    }
+
     /// Withdraw accumulated protocol fees or unused liquidity from the contract.
     /// Only callable by Admin (role 0).
     ///
@@ -2078,6 +2115,11 @@ impl PredifiContract {
 
         // Validate: end_time must be in the future
         assert!(end_time > current_time, "end_time must be in the future");
+
+        // Validate: end_time must not exceed MAX_POOL_DURATION from now
+        if end_time > current_time + MAX_POOL_DURATION {
+            soroban_sdk::panic_with_error!(&env, PredifiError::InvalidTimestamp);
+        }
 
         let min_pool_duration = env
             .storage()
@@ -3714,14 +3756,18 @@ impl PredifiContract {
             if stake == 0 {
                 current_odds.push_back(0);
             } else {
-                // Calculation: (total_stake * 10000) / stake
-                // Result is fixed-point with 4 decimal places (e.g., 2.5x odds = 25000)
-                let odds = pool
-                    .total_stake
-                    .checked_mul(10000)
-                    .expect("overflow")
-                    .checked_div(stake)
-                    .unwrap_or(0);
+                // Exclude initial_liquidity from the denominator so odds reflect
+                // only user-contributed stakes, not the creator's seed liquidity.
+                let user_stake_total = pool.total_stake.saturating_sub(pool.initial_liquidity);
+                let odds = if user_stake_total <= 0 {
+                    0
+                } else {
+                    user_stake_total
+                        .checked_mul(10000)
+                        .expect("overflow")
+                        .checked_div(stake)
+                        .unwrap_or(0)
+                };
                 current_odds.push_back(odds as u64);
             }
         }


### PR DESCRIPTION
This commit resolves three separate issues in the predifi-contract:

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue 1 — Add update_referrer function (closes #referrer-update) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Problem:
  The referral system stores a referrer address on the user's first
  prediction for a given pool. If the referrer address is later found
  to be compromised, invalid, or set by mistake, there was no way to
  update or remove it. The referrer would continue to receive a cut of
  the protocol fee on every future claim from that user for that pool.

Fix:
  Added a new public function update_referrer(user, pool_id,
  new_referrer: Option<Address>) in lib.rs.

  - Callable only by the user themselves via user.require_auth().
  - Passing Some(address) sets a new referrer for the (user, pool_id) pair by writing to DataKey::Referrer(user, pool_id).
  - Passing None removes the referral relationship entirely by calling env.storage().persistent().remove() on the key.
  - Self-referral is rejected with PredifiError::Unauthorized.
  - TTL is extended on write to keep the entry alive.

Files changed:
  - src/lib.rs: new update_referrer() function added after get_referred_volume().

closes #602 

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue 2 — Add MAX_POOL_DURATION and validate end_time upper bound
         (closes #max-pool-duration)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Problem:
  create_pool validated that end_time is in the future but placed no
  upper bound on how far in the future it could be. A pool could be
  created with an end_time 100 years from now, requiring indefinite
  storage TTL bumps and tying up initial liquidity permanently.

Fix:
  1. Added MAX_POOL_DURATION = 31_536_000 (365 days in seconds) to constants.rs.
  2. Added a new PredifiError::InvalidTimestamp = 94 variant to the error enum in lib.rs.
  3. Added validation in create_pool immediately after the existing future-time check:

       if end_time > current_time + MAX_POOL_DURATION {
           panic_with_error!(&env, PredifiError::InvalidTimestamp);
       }

Files changed:
  - src/constants.rs: MAX_POOL_DURATION constant added.
  - src/lib.rs: InvalidTimestamp = 94 added to PredifiError; upper- bound check added in create_pool.

closes #601 


━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue 3 — Fix odds calculation to exclude initial_liquidity
          (closes #odds-initial-liquidity)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Problem:
  PoolStats.current_odds was calculated as:
    odds = (total_stake * 10000) / outcome_stake
  However, total_stake includes initial_liquidity provided by the pool
  creator, which is not distributed across stakes_per_outcome. This
  inflated the denominator and produced skewed odds that did not
  accurately reflect user-contributed stakes.

Fix:
  In get_pool_stats(), the odds denominator is now computed as:
    user_stake_total = total_stake - initial_liquidity
  and odds are calculated as:
    odds = (user_stake_total * 10000) / outcome_stake
  If user_stake_total <= 0 (no user bets yet), odds default to 0 to
  avoid division by zero or misleading values.

Files changed:
  - src/lib.rs: get_pool_stats() odds loop updated to subtract pool.initial_liquidity before computing odds.

# Description

Provide a brief summary of the changes and the motivation behind them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or internal tool improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Screenshots / Recordings

> [!IMPORTANT]
> **A screenshot or screen recording is REQUIRED for all frontend/UI changes.**
> Please paste your screenshots or recordings below.

<!-- Paste screenshots/recordings here -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
closes #603 