### PR TITLE
fix: cap resolution delay to prevent protocol lockout

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -106,6 +106,9 @@ pub const CATEGORY_ENTERTAIN: Symbol = symbol_short!("Entertain");
 /// Technology and innovation predictions (e.g., product launches, tech trends)
 pub const CATEGORY_TECH: Symbol = symbol_short!("Tech");
 
+/// Maximum allowed resolution delay: 30 days in seconds
+pub const MAX_RESOLUTION_DELAY: u64 = 2_592_000;
+
 /// Miscellaneous predictions that don't fit other categories
 pub const CATEGORY_OTHER: Symbol = symbol_short!("Other");
 
@@ -1602,6 +1605,9 @@ impl PredifiContract {
         Self::require_not_paused(&env);
         admin.require_auth();
         Self::require_admin_role(&env, &admin, "set_resolution_delay")?;
+        if delay > MAX_RESOLUTION_DELAY {
+            return Err(PredifiError::InvalidData);
+        }
         let mut config = Self::get_config(&env);
         config.resolution_delay = delay;
         env.storage().instance().set(&DataKey::Config, &config);


### PR DESCRIPTION
Add MAX_RESOLUTION_DELAY constant (2_592_000s / 30 days) and validate against it in set_resolution_delay. Prevents an admin from setting an arbitrarily large delay (e.g. u64::MAX) that would permanently block pool resolution. Returns PredifiError::InvalidData on violation.

# Description

Provide a brief summary of the changes and the motivation behind them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or internal tool improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Screenshots / Recordings

> [!IMPORTANT]
> **A screenshot or screen recording is REQUIRED for all frontend/UI changes.**
> Please paste your screenshots or recordings below.

<!-- Paste screenshots/recordings here -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
closes #618 
