### PR TITLE
#624 update_price_feed allows timestamp equal to current ledger time

### DIFF
--- a/contract/contracts/predifi-contract/src/price_feed.rs
+++ b/contract/contracts/predifi-contract/src/price_feed.rs
@@ -171,8 +171,9 @@ impl PriceFeedAdapter {
             return Err(PredifiError::InvalidAmount);
         }
 
-        if timestamp > env.ledger().timestamp() || expires_at <= timestamp {
-            return Err(PredifiError::InvalidPoolState);
+        // Require timestamp to be strictly in the past (at least 1 second old)
+        if timestamp >= env.ledger().timestamp() || expires_at <= timestamp {
+            return Err(PredifiError::InvalidData);
         }
 
         let feed = PriceFeed {


### PR DESCRIPTION
### Summary

This PR fixes issue #624 by tightening timestamp validation in `update_price_feed` to prevent price feed updates from using timestamps equal to the current ledger time.

### Problem

The previous validation logic allowed:

```rust
timestamp == env.ledger().timestamp()
```

which meant oracles could submit price data using the exact current ledger timestamp. This weakens the guarantee that submitted prices represent actual observed market data rather than submission-time values.

Previous logic:

```rust
if timestamp > env.ledger().timestamp() || expires_at <= timestamp {
    return Err(PredifiError::InvalidPoolState);
}
```

### Solution

Updated validation to require timestamps to be strictly in the past:

```rust
if timestamp >= env.ledger().timestamp() || expires_at <= timestamp {
    return Err(PredifiError::InvalidData);
}
```

### Changes Made

* Replaced `>` with `>=` for stricter timestamp validation
* Prevented `timestamp == current ledger time`
* Updated error type from `InvalidPoolState` to `InvalidData`
* Added inline documentation clarifying that timestamps must be at least 1 second old

### Impact

This improves oracle data integrity by ensuring price updates always reflect prior observations and not submission-time values, strengthening security and consistency of the price feed system.

close #624
