### PR TITLE
fix(contract): validate min_stake <= max_stake in set_stake_limits

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -3356,8 +3356,8 @@ impl PredifiContract {
         if min_stake <= 0 {
             return Err(PredifiError::StakeBelowMinimum);
         }
-        if max_stake != 0 && max_stake < min_stake {
-            return Err(PredifiError::StakeAboveMaximum);
+        if max_stake > 0 && min_stake > max_stake {
+            return Err(PredifiError::InvalidAmount);
         }
 
         pool.min_stake = min_stake;

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -3614,7 +3614,7 @@ fn test_set_stake_limits_max_below_min_returns_error() {
     );
 
     let result = client.try_set_stake_limits(&operator, &pool_id, &100i128, &50i128);
-    assert_eq!(result, Err(Ok(PredifiError::StakeAboveMaximum)));
+    assert_eq!(result, Err(Ok(PredifiError::InvalidAmount)));
 }
 
 // ── #594: min_stake / max_stake boundary validation ───────────────────────────
@@ -3698,8 +3698,8 @@ fn test_set_stake_limits_min_greater_than_max_returns_error() {
     let result = client.try_set_stake_limits(&operator, &pool_id, &500i128, &100i128);
     assert_eq!(
         result,
-        Err(Ok(PredifiError::StakeAboveMaximum)),
-        "min_stake > max_stake must return StakeAboveMaximum"
+        Err(Ok(PredifiError::InvalidAmount)),
+        "min_stake > max_stake must return InvalidAmount"
     );
 }
 


### PR DESCRIPTION
Return InvalidAmount when max_stake > 0 && min_stake > max_stake to prevent pools from entering an un-stakeable state.

# Description

Provide a brief summary of the changes and the motivation behind them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or internal tool improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

closes #682 
## Screenshots / Recordings

> [!IMPORTANT]
> **A screenshot or screen recording is REQUIRED for all frontend/UI changes.**
> Please paste your screenshots or recordings below.

<!-- Paste screenshots/recordings here -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
