### PR TITLE
refactor: use sentinel for pool.outcome to distinguish unresolved state

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -470,7 +470,10 @@ pub struct UserPredictionDetail {
     /// Current operational state of the pool (Active, Resolved, or Canceled).
     pub pool_state: MarketState,
     /// The winning outcome index (0-based) if the pool is `Resolved`.
-    /// Only meaningful when `pool_state` is `MarketState::Resolved`.
+    /// Set to `UNRESOLVED_OUTCOME` (`u32::MAX`) when the pool has not yet been resolved.
+    /// Callers must check `pool_state == MarketState::Resolved` (or compare against
+    /// `UNRESOLVED_OUTCOME`) before interpreting this value; outcome index `0` is a
+    /// valid winning outcome and must not be confused with the unresolved sentinel.
     pub pool_outcome: u32,
 }
 

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -10227,3 +10227,97 @@ fn test_prediction_cooldown_resets_after_each_successful_prediction() {
     env.ledger().set_timestamp(1_120);
     client.place_prediction(&user, &pool_id, &50i128, &0u32, &None, &None);
 }
+
+// ── Sentinel / UNRESOLVED_OUTCOME tests ──────────────────────────────────────
+
+/// Unresolved pool must carry UNRESOLVED_OUTCOME (u32::MAX), not 0.
+/// After resolution to outcome 0 the field must equal 0 (not the sentinel),
+/// proving the two states are unambiguously distinguishable.
+#[test]
+fn test_pool_outcome_sentinel_before_and_after_resolution() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ac_id = env.register(dummy_access_control::DummyAccessControl, ());
+    let ac_client = dummy_access_control::DummyAccessControlClient::new(&env, &ac_id);
+    let contract_id = env.register(PredifiContract, ());
+    let client = PredifiContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_address = env.register_stellar_asset_contract(token_admin.clone());
+    let treasury = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+    ac_client.grant_role(&operator, &ROLE_OPERATOR);
+
+    client.init(&ac_id, &treasury, &0u32, &0u64, &3600u64, &0u32);
+    client.add_token_to_whitelist(&admin, &token_address);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &token_address).mint(&user, &1000);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Sentinel test pool"),
+            metadata_url: String::from_str(&env, "ipfs://test"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+        },
+    );
+
+    // Before resolution: outcome must be UNRESOLVED_OUTCOME (u32::MAX), not 0
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(
+        pool.outcome,
+        u32::MAX,
+        "unresolved pool must carry UNRESOLVED_OUTCOME sentinel (u32::MAX), not 0"
+    );
+    assert_eq!(pool.state, MarketState::Active);
+
+    // Place a prediction so get_user_predictions is populated
+    client.place_prediction(&user, &pool_id, &100i128, &0u32, &None, &None);
+
+    // UserPredictionDetail.pool_outcome must also be the sentinel before resolution
+    let details = client.get_user_predictions(&user, &0u32, &10u32);
+    let detail = details.get(0).unwrap();
+    assert_eq!(
+        detail.pool_outcome,
+        u32::MAX,
+        "UserPredictionDetail.pool_outcome must be UNRESOLVED_OUTCOME before resolution"
+    );
+
+    // Resolve to outcome 0 — must be distinguishable from the sentinel
+    env.ledger().with_mut(|li| li.timestamp = 100001);
+    client.resolve_pool(&operator, &pool_id, &0u32);
+
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.state, MarketState::Resolved);
+    assert_eq!(
+        pool.outcome, 0u32,
+        "after resolving to outcome 0, pool.outcome must be 0, not the sentinel"
+    );
+    assert_ne!(
+        pool.outcome,
+        u32::MAX,
+        "resolved pool must not carry the UNRESOLVED_OUTCOME sentinel"
+    );
+}


### PR DESCRIPTION
Closes #695

---

## Summary

Closes the ambiguity between "Outcome 0 won" and "pool not yet resolved".

The sentinel `UNRESOLVED_OUTCOME = u32::MAX` was already set at pool creation and checked in `is_pool_resolved`, but `UserPredictionDetail.pool_outcome` only said "only meaningful when Resolved" — leaving callers to potentially assume `0` means unresolved.

## Changes

**`lib.rs`** — Expanded `UserPredictionDetail.pool_outcome` doc comment to explicitly state:
- The field holds `UNRESOLVED_OUTCOME` (`u32::MAX`) before resolution
- Outcome index `0` is a valid winning outcome and must not be confused with the sentinel

**`test.rs`** — `test_pool_outcome_sentinel_before_and_after_resolution` asserts:
- Fresh pool: `pool.outcome == u32::MAX` (not `0`)
- `UserPredictionDetail.pool_outcome == u32::MAX` before resolution
- After resolving to outcome `0`: `pool.outcome == 0` and `!= u32::MAX`