### PR TITLE
fix(contract): enforce strict category validation in create_pool

### DIFF
--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -843,13 +843,14 @@ fn test_multiple_pools_independent() {
 }
 
 #[test]
-fn test_invalid_category_fallback() {
+#[should_panic(expected = "Error(Contract, #90)")]
+fn test_invalid_category_fails() {
     let env = Env::default();
     env.mock_all_auths();
 
     let (_, client, token_address, _, _, _, _, creator) = setup(&env);
 
-    let pool_id = client.create_pool(
+    client.create_pool(
         &creator,
         &100000u64,
         &token_address,
@@ -873,9 +874,6 @@ fn test_invalid_category_fallback() {
             ],
         },
     );
-
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.category, CATEGORY_OTHER);
 }
 
 // ── Access control tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
closes #684 
Replace silent fallback-to-Other behavior with an explicit error. validate_category already returns Err(InvalidData) for unrecognized symbols; update the stale test to expect a panic (Error(Contract, #90)) instead of asserting the old fallback behavior.

Closes: strict category validation bug

# Description

Provide a brief summary of the changes and the motivation behind them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or internal tool improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Screenshots / Recordings

> [!IMPORTANT]
> **A screenshot or screen recording is REQUIRED for all frontend/UI changes.**
> Please paste your screenshots or recordings below.

<!-- Paste screenshots/recordings here -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
