### PR TITLE
Validate treasury withdraw amount and balance

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -2070,17 +2070,17 @@ impl PredifiContract {
         // Verify admin role
         Self::require_admin_role(&env, &admin, "withdraw_treasury")?;
 
-        // Validate amount meets minimum threshold
-        if amount < MIN_WITHDRAWAL_AMOUNT {
+        // Reject zero or negative withdrawals before touching token state.
+        if amount <= 0 || amount < MIN_WITHDRAWAL_AMOUNT {
             return Err(PredifiError::InvalidAmount);
         }
 
-        // Get token client and check balance
+        // Get token client and check the contract's available balance first.
         let token_client = token::Client::new(&env, &token);
-        let contract_balance = token_client.balance(&env.current_contract_address());
+        let available_balance = token_client.balance(&env.current_contract_address());
 
         // Verify sufficient balance
-        if contract_balance < amount {
+        if available_balance < amount {
             return Err(PredifiError::InsufficientBalance);
         }
 

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -3907,7 +3907,6 @@ fn test_admin_can_withdraw_treasury() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #10)")]
 fn test_non_admin_cannot_withdraw_treasury() {
     let env = Env::default();
     env.mock_all_auths();
@@ -3918,12 +3917,11 @@ fn test_non_admin_cannot_withdraw_treasury() {
 
     token_admin_client.mint(&contract_addr, &5000);
 
-    // Non-admin tries to withdraw - should panic
-    client.withdraw_treasury(&non_admin, &token_address, &3000, &treasury);
+    let result = client.try_withdraw_treasury(&non_admin, &token_address, &3000, &treasury);
+    assert_eq!(result, Err(Ok(PredifiError::Unauthorized)));
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #42)")]
 fn test_withdraw_treasury_rejects_zero_amount() {
     let env = Env::default();
     env.mock_all_auths();
@@ -3936,12 +3934,11 @@ fn test_withdraw_treasury_rejects_zero_amount() {
 
     token_admin_client.mint(&contract_addr, &5000);
 
-    // Try to withdraw zero amount - should panic
-    client.withdraw_treasury(&admin, &token_address, &0, &treasury);
+    let result = client.try_withdraw_treasury(&admin, &token_address, &0, &treasury);
+    assert_eq!(result, Err(Ok(PredifiError::InvalidAmount)));
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #44)")]
 fn test_withdraw_treasury_rejects_insufficient_balance() {
     let env = Env::default();
     env.mock_all_auths();
@@ -3954,8 +3951,8 @@ fn test_withdraw_treasury_rejects_insufficient_balance() {
 
     token_admin_client.mint(&contract_addr, &1000);
 
-    // Try to withdraw more than balance - should panic
-    client.withdraw_treasury(&admin, &token_address, &5000, &treasury);
+    let result = client.try_withdraw_treasury(&admin, &token_address, &5000, &treasury);
+    assert_eq!(result, Err(Ok(PredifiError::InsufficientBalance)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Closes #687

This PR hardens `withdraw_treasury` by validating the requested withdraw amount before transfer and returning the proper contract error when the requested amount exceeds the contract's available token balance.

## What Changed
- Explicitly reject zero or negative treasury withdrawals with `PredifiError::InvalidAmount`
- Check the contract's available token balance before transfer
- Return `PredifiError::InsufficientBalance` when the requested withdraw amount is greater than the available balance
- Update withdrawal tests to assert exact returned contract errors instead of only panic behavior

## Why
This prevents:
- zero-value treasury withdrawals
- withdrawing more than the contract currently holds for the selected token

It also makes the error behavior clearer and easier for callers/tests to rely on.

## Testing
- `cargo fmt --package predifi-contract`
- Attempted: `cargo test withdraw_treasury --package predifi-contract`

## Notes
I could not complete the targeted Rust test run locally because the workspace currently hits an unrelated Windows GNU linker failure while building `access-control`:

`export ordinal too large: 73106`
