### PR TITLE
feat(backend): testcontainers integration for DB tests in CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -127,7 +127,7 @@ jobs:
   backend-checks:
     name: Backend Checks
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     defaults:
       run:
@@ -162,5 +162,5 @@ jobs:
       - name: Build backend
         run: cargo build --release
 
-      - name: Run unit tests
+      - name: Run tests (unit + integration)
         run: cargo test

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -39,3 +39,5 @@ tower_governor = { version = "0.5.0", features = ["axum"] }
 [dev-dependencies]
 http-body-util = "0.1"
 tower = { version = "0.4", features = ["util"] }
+testcontainers = "0.23"
+testcontainers-modules = { version = "0.11", features = ["postgres"] }

--- a/backend/src/db_integration_tests.rs
+++ b/backend/src/db_integration_tests.rs
@@ -1,0 +1,122 @@
+//! Integration tests for the database layer using testcontainers-rs.
+//!
+//! Each test spins up a throwaway Postgres container, runs all migrations,
+//! and exercises the real SQL queries — no pre-configured database required.
+
+#[cfg(test)]
+mod tests {
+    use sqlx::{postgres::PgPoolOptions, PgPool, Row};
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    /// Boot a Postgres container, run all migrations, and return the pool.
+    async fn setup() -> (PgPool, testcontainers::ContainerAsync<Postgres>) {
+        let container = Postgres::default().start().await.expect("postgres container");
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("postgres port");
+        let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&url)
+            .await
+            .expect("connect to test postgres");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+
+        (pool, container)
+    }
+
+    #[tokio::test]
+    async fn migrations_run_cleanly() {
+        let (_pool, _container) = setup().await;
+        // If setup() completes without panic the migrations are valid.
+    }
+
+    #[tokio::test]
+    async fn insert_and_query_pool() {
+        let (pool, _container) = setup().await;
+
+        sqlx::query(
+            "INSERT INTO pools (metadata_url, start_time, end_time) \
+             VALUES ($1, NOW(), NOW() + INTERVAL '1 day')",
+        )
+        .bind("https://example.com/pool/1")
+        .execute(&pool)
+        .await
+        .expect("insert pool");
+
+        let count: i64 = sqlx::query("SELECT COUNT(*) FROM pools")
+            .fetch_one(&pool)
+            .await
+            .expect("count pools")
+            .get(0);
+
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn insert_and_query_prediction() {
+        let (pool, _container) = setup().await;
+
+        let pool_id: i64 = sqlx::query(
+            "INSERT INTO pools (metadata_url, start_time, end_time) \
+             VALUES ($1, NOW(), NOW() + INTERVAL '1 day') RETURNING id",
+        )
+        .bind("https://example.com/pool/2")
+        .fetch_one(&pool)
+        .await
+        .expect("insert pool")
+        .get(0);
+
+        sqlx::query(
+            "INSERT INTO predictions (pool_id, user_address, outcome, amount) \
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(pool_id)
+        .bind("GABC1234")
+        .bind(1_i32)
+        .bind(500_i64)
+        .execute(&pool)
+        .await
+        .expect("insert prediction");
+
+        let count: i64 =
+            sqlx::query("SELECT COUNT(*) FROM predictions WHERE user_address = $1")
+                .bind("GABC1234")
+                .fetch_one(&pool)
+                .await
+                .expect("count predictions")
+                .get(0);
+
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn pool_status_defaults_to_open() {
+        let (pool, _container) = setup().await;
+
+        sqlx::query(
+            "INSERT INTO pools (metadata_url, start_time, end_time) \
+             VALUES ($1, NOW(), NOW() + INTERVAL '1 day')",
+        )
+        .bind("https://example.com/pool/3")
+        .execute(&pool)
+        .await
+        .expect("insert pool");
+
+        let status: String =
+            sqlx::query("SELECT status FROM pools ORDER BY id DESC LIMIT 1")
+                .fetch_one(&pool)
+                .await
+                .expect("fetch status")
+                .get(0);
+
+        assert_eq!(status, "Open");
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -179,3 +179,5 @@ async fn main() {
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod db_integration_tests;


### PR DESCRIPTION
Closes #675

---

## Summary
Adds reliable integration tests for the database layer using `testcontainers-rs`. No pre-configured database is required — each test run boots a throwaway Postgres container.

## Changes
- `backend/Cargo.toml`: added `testcontainers = "0.23"` and `testcontainers-modules = { version = "0.11", features = ["postgres"] }` to `[dev-dependencies]`
- `backend/src/db_integration_tests.rs`: 4 integration tests (migrations, pool insert/query, prediction insert/query, default status constraint)
- `backend/src/main.rs`: declared `mod db_integration_tests` under `#[cfg(test)]`
- `.github/workflows/backend.yml`: bumped `backend-checks` timeout to 20 min; unified test step to run unit + integration tests

## Acceptance Criteria
- `cargo test` passes locally and in GitHub Actions without a pre-configured DB
- Docker daemon (available on `ubuntu-latest` runners) is the only requirement