### PR TITLE
fix: validate fee tiers thresholds are strictly ascending

### DIFF
--- a/contract/contracts/predifi-contract/src/fee_tiers_test.rs
+++ b/contract/contracts/predifi-contract/src/fee_tiers_test.rs
@@ -171,6 +171,54 @@ fn test_dynamic_fee_tiers_application() {
 }
 
 #[test]
+fn test_set_fee_tiers_unsorted_thresholds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (ac_client, client, _, _, _, _, _, _) = crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let tiers = Vec::from_array(
+        &env,
+        [
+            FeeTier { stake_threshold: 5_000_000, fee_bps: 50 },
+            FeeTier { stake_threshold: 1_000_000, fee_bps: 100 }, // out of order
+        ],
+    );
+
+    let result = client.try_set_fee_tiers(&admin, &tiers);
+    assert_eq!(
+        result.err().unwrap().unwrap(),
+        crate::PredifiError::InvalidFeeBps
+    );
+}
+
+#[test]
+fn test_set_fee_tiers_duplicate_thresholds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (ac_client, client, _, _, _, _, _, _) = crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let tiers = Vec::from_array(
+        &env,
+        [
+            FeeTier { stake_threshold: 1_000_000, fee_bps: 100 },
+            FeeTier { stake_threshold: 1_000_000, fee_bps: 50 }, // duplicate threshold
+        ],
+    );
+
+    let result = client.try_set_fee_tiers(&admin, &tiers);
+    assert_eq!(
+        result.err().unwrap().unwrap(),
+        crate::PredifiError::InvalidFeeBps
+    );
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #10)")]
 fn test_set_fee_tiers_unauthorized() {
     let env = Env::default();

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -4032,6 +4032,13 @@ impl PredifiContract {
                 if tier.fee_bps > 10_000 {
                     return Err(PredifiError::InvalidFeeBps);
                 }
+                if i > 0 {
+                    if let Some(prev) = tiers.get(i - 1) {
+                        if tier.stake_threshold <= prev.stake_threshold {
+                            return Err(PredifiError::InvalidFeeBps);
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Closes #677

---

## Summary

Fixes a bug where `set_fee_tiers` accepted tiers with out-of-order or duplicate `stake_threshold` values, which would cause incorrect fee lookups.

## Changes

- **`set_fee_tiers`**: Added validation inside the existing loop to ensure each tier's `stake_threshold` is strictly greater than the previous one. Returns `InvalidFeeBps` if not.
- **`fee_tiers_test.rs`**: Added two tests:
  - `test_set_fee_tiers_unsorted_thresholds` — descending order returns `InvalidFeeBps`
  - `test_set_fee_tiers_duplicate_thresholds` — equal thresholds return `InvalidFeeBps`

## Acceptance Criteria Met

- `set_fee_tiers` returns `InvalidFeeBps` if thresholds are not strictly ascending.