### PR TITLE
feat: Referral Earnings Dashboard API

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -135,6 +135,40 @@ pub async fn insert_pool_from_event(
     Ok(())
 }
 
+/// A single row in the referral earnings breakdown — one entry per pool.
+#[derive(Debug, serde::Serialize, sqlx::FromRow)]
+pub struct ReferralEarningRow {
+    pub pool_id: i64,
+    pub pool_name: String,
+    pub total_earned: i64,
+    pub referral_count: i64,
+}
+
+/// Fetch referral earnings grouped by pool for a given referrer address.
+pub async fn get_referral_earnings(
+    pool: &PgPool,
+    address: &str,
+) -> Result<Vec<ReferralEarningRow>, sqlx::Error> {
+    sqlx::query_as!(
+        ReferralEarningRow,
+        r#"
+        SELECT
+            r.pool_id,
+            pl.name          AS pool_name,
+            SUM(r.amount)    AS "total_earned!: i64",
+            COUNT(r.id)      AS "referral_count!: i64"
+        FROM referrals r
+        JOIN pools pl ON pl.pool_id = r.pool_id
+        WHERE r.referrer = $1
+        GROUP BY r.pool_id, pl.name
+        ORDER BY total_earned DESC
+        "#,
+        address
+    )
+    .fetch_all(pool)
+    .await
+}
+
 /// Decoded data from a `pool_created` contract event.
 #[derive(Debug)]
 pub struct PoolCreatedEvent {

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -72,6 +72,26 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+/// Per-pool referral earnings entry.
+#[derive(Debug, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct ReferralEarningDoc {
+    pub pool_id: i64,
+    pub pool_name: String,
+    /// Total amount earned from referrals in this pool (stroops).
+    pub total_earned: i64,
+    /// Number of referred users who staked in this pool.
+    pub referral_count: i64,
+}
+
+/// Referral earnings breakdown response.
+#[derive(Debug, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct ReferralEarningsResponse {
+    pub referrer: String,
+    /// Aggregate earnings across all pools (stroops).
+    pub total_earned: i64,
+    pub pools: Vec<ReferralEarningDoc>,
+}
+
 // ── OpenAPI spec definition ───────────────────────────────────────────────────
 
 #[derive(OpenApi)]
@@ -87,6 +107,7 @@ pub struct ErrorResponse {
         api_get_pools,
         api_get_pool_by_id,
         api_get_user_history,
+        api_get_user_referral_earnings,
         api_health,
     ),
     components(
@@ -95,12 +116,15 @@ pub struct ErrorResponse {
             PredictionDoc,
             PoolListResponse,
             PredictionHistoryResponse,
+            ReferralEarningDoc,
+            ReferralEarningsResponse,
             ErrorResponse,
         )
     ),
     tags(
         (name = "pools", description = "Active prediction market pools"),
         (name = "predictions", description = "User prediction history"),
+        (name = "referrals", description = "Referral earnings dashboard"),
         (name = "health", description = "Service health endpoints"),
     )
 )]
@@ -172,6 +196,22 @@ async fn api_get_user_history() {}
     )
 )]
 async fn api_health() {}
+
+/// `GET /api/v1/users/{address}/referrals` — per-pool referral earnings for a user.
+#[utoipa::path(
+    get,
+    path = "/api/v1/users/{address}/referrals",
+    tag = "referrals",
+    params(
+        ("address" = String, Path, description = "Stellar referrer address (G...)"),
+    ),
+    responses(
+        (status = 200, description = "Referral earnings breakdown per pool", body = ReferralEarningsResponse),
+        (status = 404, description = "No referral records found", body = ErrorResponse),
+        (status = 503, description = "Database not configured", body = ErrorResponse),
+    )
+)]
+async fn api_get_user_referral_earnings() {}
 
 // ── Swagger UI router ─────────────────────────────────────────────────────────
 

--- a/backend/src/referrals.rs
+++ b/backend/src/referrals.rs
@@ -37,6 +37,7 @@ use axum::{
 use serde::Serialize;
 use sqlx::PgPool;
 
+use crate::db::ReferralEarningRow;
 use crate::response::ApiResponse;
 
 /// Summary statistics for a single referrer address.
@@ -90,6 +91,42 @@ pub async fn get_referrals(
         }),
         Err(err) => {
             tracing::error!(error = %err, "referrals query failed");
+            ApiResponse::error(StatusCode::INTERNAL_SERVER_ERROR, "database error")
+        }
+    }
+}
+
+/// Response body for `GET /api/v1/users/:address/referrals`.
+#[derive(Debug, Serialize)]
+pub struct ReferralEarningsResponse {
+    pub referrer: String,
+    pub total_earned: i64,
+    pub pools: Vec<ReferralEarningRow>,
+}
+
+/// `GET /api/v1/users/:address/referrals`
+///
+/// Returns per-pool referral earnings for the given referrer address.
+/// Responds with 404 if the address has no referral records.
+pub async fn get_user_referral_earnings(
+    Path(address): Path<String>,
+    State(pool): State<PgPool>,
+) -> (StatusCode, Json<ApiResponse<ReferralEarningsResponse>>) {
+    match crate::db::get_referral_earnings(&pool, &address).await {
+        Ok(rows) if rows.is_empty() => ApiResponse::error(
+            StatusCode::NOT_FOUND,
+            format!("no referral earnings found for {address}"),
+        ),
+        Ok(rows) => {
+            let total_earned = rows.iter().map(|r| r.total_earned).sum();
+            ApiResponse::success(ReferralEarningsResponse {
+                referrer: address,
+                total_earned,
+                pools: rows,
+            })
+        }
+        Err(err) => {
+            tracing::error!(error = %err, "referral earnings query failed");
             ApiResponse::error(StatusCode::INTERNAL_SERVER_ERROR, "database error")
         }
     }

--- a/backend/src/routes/v1.rs
+++ b/backend/src/routes/v1.rs
@@ -172,7 +172,7 @@ pub fn router(config: Config, cache: PriceCache, pool: Option<sqlx::PgPool>) -> 
     let state = AppState {
         config,
         cache,
-        pool,
+        db: pool,
     };
 
     Router::new()
@@ -181,6 +181,7 @@ pub fn router(config: Config, cache: PriceCache, pool: Option<sqlx::PgPool>) -> 
         .route("/fees", get(get_fees))
         .route("/prices", get(crate::price_cache::get_prices))
         .route("/referrals/{address}", get(referrals_handler))
+        .route("/users/{address}/referrals", get(user_referral_earnings_handler))
         .with_state(state)
 }
 
@@ -207,6 +208,32 @@ async fn referrals_handler(
         Some(pool) => {
             let (status, body) =
                 crate::referrals::get_referrals(axum::extract::Path(address), State(pool)).await;
+            (status, body).into_response()
+        }
+        None => {
+            ApiResponse::<()>::error(StatusCode::SERVICE_UNAVAILABLE, "database not configured")
+                .into_response()
+        }
+    }
+}
+
+/// `GET /api/v1/users/:address/referrals` — per-pool referral earnings for a user.
+async fn user_referral_earnings_handler(
+    axum::extract::Path(address): axum::extract::Path<String>,
+    State(state): State<AppState>,
+) -> axum::response::Response {
+    use crate::response::ApiResponse;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    match state.db {
+        Some(pool) => {
+            let (status, body) =
+                crate::referrals::get_user_referral_earnings(
+                    axum::extract::Path(address),
+                    State(pool),
+                )
+                .await;
             (status, body).into_response()
         }
         None => {

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -242,3 +242,20 @@ async fn rate_limiting_returns_429_after_burst() {
 
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
 }
+
+/// GET /api/v1/users/:address/referrals without a DB returns 503.
+#[tokio::test]
+async fn user_referrals_without_db_returns_503() {
+    let response = build_router(Config::default_for_test(), PriceCache::new())
+        .oneshot(get("/api/v1/users/GABC123/referrals"))
+        .await
+        .expect("request failed");
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body = body_string(response.into_body()).await;
+    assert!(
+        body.contains("database not configured"),
+        "body should mention database not configured, got: {body}"
+    );
+}


### PR DESCRIPTION
Closes #673

---

## Summary
Implements `GET /api/v1/users/:address/referrals` — per-pool referral earnings breakdown.

## Changes
- **`db.rs`** — `ReferralEarningRow` struct + `get_referral_earnings()` query joining `referrals` with `pools`, grouped by pool
- **`referrals.rs`** — `get_user_referral_earnings()` handler; returns 404 (no records), 500 (DB error), or 200 with breakdown
- **`routes/v1.rs`** — registered `/users/{address}/referrals` route; fixed pre-existing `AppState { pool }` → `AppState { db: pool }` bug
- **`openapi.rs`** — `ReferralEarningDoc` / `ReferralEarningsResponse` schemas + path stub + `referrals` tag
- **`tests.rs`** — `user_referrals_without_db_returns_503` unit test

## Response shape
```json
{
  "status": "success",
  "data": {
    "referrer": "GABC...",
    "total_earned": 15000,
    "pools": [
      { "pool_id": 1, "pool_name": "BTC > 100k?", "total_earned": 10000, "referral_count": 4 },
      { "pool_id": 3, "pool_name": "ETH Merge 2.0", "total_earned": 5000, "referral_count": 2 }
    ]
  }
}
```

## Tested
- Unit test covers no-DB 503 path (cargo unavailable in dev container; CI will run full suite)