### PR TITLE
fix: correct odds calculation in get_pool_stats

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -3752,13 +3752,13 @@ impl PredifiContract {
             if stake == 0 {
                 current_odds.push_back(0);
             } else {
-                // Exclude initial_liquidity from the denominator so odds reflect
-                // only user-contributed stakes, not the creator's seed liquidity.
-                let user_stake_total = pool.total_stake.saturating_sub(pool.initial_liquidity);
-                let odds = if user_stake_total <= 0 {
+                // Include initial_liquidity in the denominator so odds reflect
+                // the true probability including house money.
+                let total_for_odds = pool.total_stake;
+                let odds = if total_for_odds <= 0 {
                     0
                 } else {
-                    user_stake_total
+                    total_for_odds
                         .checked_mul(10000)
                         .expect("overflow")
                         .checked_div(stake)

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -4184,6 +4184,59 @@ fn test_get_pool_stats() {
     assert_eq!(stats.current_odds.get(1), Some(16666));
 }
 
+fn test_get_pool_stats_with_initial_liquidity() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, token_admin_client, _, _, creator) = setup(&env);
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    token_admin_client.mint(&user1, &5000);
+    token_admin_client.mint(&user2, &5000);
+
+    // Create pool with initial liquidity of 1000
+    let pool_id = client.create_pool(
+        &creator,
+        &100000u64,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            description: String::from_str(&env, "Initial Liquidity Test"),
+            metadata_url: String::from_str(&env, "ipfs://metadata"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 1000i128, // House provides 1000 initial liquidity
+            required_resolutions: 1u32, private: false, whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![&env, String::from_str(&env, "Yes"), String::from_str(&env, "No")],
+        },
+    );
+
+    // Initial stats should show initial_liquidity in total_stake
+    let stats = client.get_pool_stats(&pool_id);
+    assert_eq!(stats.total_stake, 1000); // Only initial_liquidity
+
+    // User 1 bets 500 on outcome 0
+    client.place_prediction(&user1, &pool_id, &500, &0, &None, &None);
+    // User 2 bets 500 on outcome 1
+    client.place_prediction(&user2, &pool_id, &500, &1, &None, &None);
+
+    let stats = client.get_pool_stats(&pool_id);
+    assert_eq!(stats.total_stake, 2000); // 1000 initial + 500 + 500
+    assert_eq!(stats.stakes_per_outcome.get(0), Some(500));
+    assert_eq!(stats.stakes_per_outcome.get(1), Some(500));
+
+    // Odds should include initial_liquidity in denominator:
+    // Total for odds = 2000 (includes initial_liquidity)
+    // Outcome 0: (2000 * 10000) / 500 = 40000 (4.0x)
+    // Outcome 1: (2000 * 10000) / 500 = 40000 (4.0x)
+    assert_eq!(stats.current_odds.get(0), Some(40000));
+    assert_eq!(stats.current_odds.get(1), Some(40000));
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // EDGE-CASE TESTS  (#327)
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
 Summary
Fixes incorrect odds calculation by including initial liquidity in the denominator of get_pool_stats.

Problem
Initial liquidity (house funds) was not included in total stake calculation, leading to skewed probability distribution.

Fix
- Included initial_liquidity in odds denominator
- Ensures correct probability distribution in pools

Issue
Closes #691