### PR TITLE
test(contract): verify treasury intake per fee tier (#705)

### DIFF
--- a/contract/contracts/predifi-contract/src/fee_tiers_test.rs
+++ b/contract/contracts/predifi-contract/src/fee_tiers_test.rs
@@ -5,7 +5,7 @@ use crate::{FeeTier, PoolConfig};
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Ledger},
-    vec, Address, Env, String, Vec,
+    token, vec, Address, Env, String, Vec,
 };
 
 #[test]
@@ -168,6 +168,129 @@ fn test_dynamic_fee_tiers_application() {
 
     let pool3 = client.get_pool(&pool_id_3);
     assert_eq!(pool3.fee_bps, 50); // Should apply 0.5% tier
+}
+
+/// Verifies that the contract retains the correct fee amount (treasury intake)
+/// for each fee tier after winners claim their winnings.
+///
+/// Tier setup:
+///   - Default (fallback): 300 bps (3%)
+///   - Tier 1: stake >= 1_000 → 100 bps (1%)
+///   - Tier 2: stake >= 5_000 → 50 bps (0.5%)
+///
+/// For each pool a single user stakes the full amount on the winning outcome,
+/// so fee = total_stake * fee_bps / 10_000 (integer floor).
+#[test]
+fn test_fee_tier_treasury_intake() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // ── Manual setup so we can control fee_bps in init ───────────────────────
+    use crate::test::ROLE_OPERATOR;
+
+    let ac_id = env.register(
+        crate::test::dummy_access_control::DummyAccessControl,
+        (),
+    );
+    let ac_client =
+        crate::test::dummy_access_control::DummyAccessControlClient::new(&env, &ac_id);
+    let contract_id = env.register(crate::PredifiContract, ());
+    let client = crate::PredifiContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract(token_admin.clone());
+    let token = token::Client::new(&env, &token_contract);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract);
+
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+    ac_client.grant_role(&operator, &ROLE_OPERATOR);
+
+    // Init with 3% fallback fee
+    client.init(&ac_id, &Address::generate(&env), &300u32, &0u64, &3600u64, &0u32);
+    client.add_token_to_whitelist(&admin, &token_contract);
+
+    // Fee tiers (small numbers for easy math)
+    // Tier 1: total_stake >= 1_000 → 1% (100 bps)
+    // Tier 2: total_stake >= 5_000 → 0.5% (50 bps)
+    let tiers = Vec::from_array(
+        &env,
+        [
+            FeeTier { stake_threshold: 1_000, fee_bps: 100 },
+            FeeTier { stake_threshold: 5_000, fee_bps: 50 },
+        ],
+    );
+    client.set_fee_tiers(&admin, &tiers);
+
+    let make_pool = |end_time: u64| -> u64 {
+        client.create_pool(
+            &creator,
+            &end_time,
+            &token_contract,
+            &2u32,
+            &symbol_short!("Tech"),
+            &PoolConfig {
+                description: String::from_str(&env, "pool"),
+                metadata_url: String::from_str(&env, "ipfs://x"),
+                min_stake: 1i128,
+                max_stake: 0i128,
+                max_total_stake: 0,
+                min_total_stake: 1,
+                initial_liquidity: 0i128,
+                required_resolutions: 1u32,
+                private: false,
+                whitelist_key: None,
+                outcome_descriptions: vec![
+                    &env,
+                    String::from_str(&env, "A"),
+                    String::from_str(&env, "B"),
+                ],
+            },
+        )
+    };
+
+    // ── Pool 1: stake = 500 → below tier 1, uses fallback 3% ─────────────────
+    // fee = 500 * 300 / 10_000 = 15
+    let user1 = Address::generate(&env);
+    token_admin_client.mint(&user1, &500);
+    let t1 = env.ledger().timestamp() + 10_000;
+    let pid1 = make_pool(t1);
+    client.place_prediction(&user1, &pid1, &500, &0, &None, &None);
+    env.ledger().set_timestamp(t1 + 3_601);
+    client.resolve_pool(&operator, &pid1, &0);
+    client.claim_winnings(&user1, &pid1);
+    let fee1 = token.balance(&contract_id);
+    assert_eq!(fee1, 15, "tier fallback (3%): expected fee 15, got {fee1}");
+
+    // ── Pool 2: stake = 2_000 → tier 1 (1%) ──────────────────────────────────
+    // fee = 2_000 * 100 / 10_000 = 20
+    let user2 = Address::generate(&env);
+    token_admin_client.mint(&user2, &2_000);
+    let t2 = env.ledger().timestamp() + 10_000;
+    let pid2 = make_pool(t2);
+    client.place_prediction(&user2, &pid2, &2_000, &0, &None, &None);
+    env.ledger().set_timestamp(t2 + 3_601);
+    client.resolve_pool(&operator, &pid2, &0);
+    client.claim_winnings(&user2, &pid2);
+    // contract now holds fee1 + fee2
+    let fee2 = token.balance(&contract_id) - fee1;
+    assert_eq!(fee2, 20, "tier 1 (1%): expected fee 20, got {fee2}");
+
+    // ── Pool 3: stake = 6_000 → tier 2 (0.5%) ────────────────────────────────
+    // fee = 6_000 * 50 / 10_000 = 30
+    let user3 = Address::generate(&env);
+    token_admin_client.mint(&user3, &6_000);
+    let t3 = env.ledger().timestamp() + 10_000;
+    let pid3 = make_pool(t3);
+    client.place_prediction(&user3, &pid3, &6_000, &0, &None, &None);
+    env.ledger().set_timestamp(t3 + 3_601);
+    client.resolve_pool(&operator, &pid3, &0);
+    client.claim_winnings(&user3, &pid3);
+    let fee3 = token.balance(&contract_id) - fee1 - fee2;
+    assert_eq!(fee3, 30, "tier 2 (0.5%): expected fee 30, got {fee3}");
 }
 
 #[test]


### PR DESCRIPTION
Closes #705

## What
Adds `test_fee_tier_treasury_intake` to `fee_tiers_test.rs`.

The existing `test_dynamic_fee_tiers_application` only asserted that `pool.fee_bps` was set correctly. This test goes further and verifies that the contract actually **retains the correct fee amount** after winners call `claim_winnings` — i.e. the treasury intake is correct for each tier.

## How
Three pools run through the full lifecycle (stake → resolve → claim_winnings), each hitting a different fee tier:

| Pool | Stake | Tier | fee_bps | Expected fee |
|------|-------|------|---------|-------------|
| 1 | 500 | fallback | 300 (3%) | 15 |
| 2 | 2,000 | tier 1 | 100 (1%) | 20 |
| 3 | 6,000 | tier 2 | 50 (0.5%) | 30 |

After each `claim_winnings`, the test asserts `token.balance(&contract_id)` has grown by exactly the expected fee.