### PR TITLE
SafeMath::proportion rejects valid edge case where numerator == denominator

### DIFF
--- a/contract/contracts/predifi-contract/src/safe_math.rs
+++ b/contract/contracts/predifi-contract/src/safe_math.rs
@@ -97,10 +97,12 @@ impl SafeMath {
     /// This is the core function for payout calculations.
     ///
     /// # Arguments
-    /// * `numerator` - The user's stake or share
-    /// * `denominator` - The total stake or pool
+    /// * `numerator` - The user's stake (must be >= 0 and <= denominator)
+    /// * `denominator` - The total stake (must be > 0)
     /// * `amount` - The amount to distribute proportionally
     /// * `rounding` - Rounding mode to use
+    ///
+    /// Note: numerator == denominator is valid and represents a 100% proportional share.
     ///
     /// # Returns
     /// The proportional amount or an error


### PR DESCRIPTION
closed #621
## Summary

Clarifies the doc comment on SafeMath::proportion to explicitly document that 
numerator == denominator is a valid input representing a 100% proportional 
share.

## Problem

The existing doc comment described numerator and denominator loosely as "the 
user's stake or share" and "the total stake or pool" without specifying their 
valid ranges. This was misleading — it implied that numerator == denominator 
might be an error case, when in fact the implementation correctly allows it.

This matters in a real scenario: if a user is the only predictor on the winning 
outcome, their user_stake equals winning_stake, making numerator == denominator.
The function handles this correctly (the guard is numerator > denominator, not 
>=), but the documentation did not make this clear.

## Change

Updated the # Arguments section of the proportion doc comment in safe_math.rs:

- numerator: now documented as must be >= 0 and <= denominator
- denominator: now documented as must be > 0
- Added a Note explicitly stating that numerator == denominator is valid and 
represents a 100% proportional share

## What was NOT changed

- No logic changes — the implementation was already correct
- No tests added or removed — existing behavior is unchanged

## Files Changed

- contract/contracts/predifi-contract/src/safe_math.rs — doc comment only

