### PR TITLE
Validate platform fee basis points

### DIFF
--- a/contract/contracts/predifi-contract/src/constants.rs
+++ b/contract/contracts/predifi-contract/src/constants.rs
@@ -48,6 +48,9 @@ pub const MAX_OPTIONS_COUNT: u32 = 100;
 /// At 7 decimal places (e.g., USDC on Stellar), this equals 100,000,000 USDC.
 pub const MAX_INITIAL_LIQUIDITY: i128 = 100_000_000_000_000;
 
+/// Maximum protocol fee in basis points. 10,000 bps equals 100%.
+pub const MAX_FEE_BPS: u32 = 10_000;
+
 /// Sentinel value used to indicate that a pool outcome has not been resolved yet.
 /// This allows us to distinguish between "outcome 0 won" and "pool not resolved".
 pub const UNRESOLVED_OUTCOME: u32 = u32::MAX;
@@ -108,6 +111,11 @@ mod tests {
     #[test]
     fn test_max_initial_liquidity_is_positive() {
         assert!(MAX_INITIAL_LIQUIDITY > 0);
+    }
+
+    #[test]
+    fn test_max_fee_bps_equals_100_percent() {
+        assert_eq!(MAX_FEE_BPS, 10_000);
     }
 
     #[test]

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -1155,7 +1155,7 @@ impl PredifiContract {
     /// POST: returns true iff fee_bps ≤ 10_000 (INV-6)
     #[allow(dead_code)]
     fn is_valid_fee_bps(fee_bps: u32) -> bool {
-        fee_bps <= 10_000
+        fee_bps <= MAX_FEE_BPS
     }
 
     /// Pure: Check if a pool is currently active.
@@ -1500,6 +1500,9 @@ impl PredifiContract {
             if resolution_delay > MAX_RESOLUTION_DELAY {
                 soroban_sdk::panic_with_error!(&env, PredifiError::InvalidData);
             }
+            if !Self::is_valid_fee_bps(fee_bps) {
+                soroban_sdk::panic_with_error!(&env, PredifiError::InvalidFeeBps);
+            }
 
             let config = Config {
                 fee_bps,
@@ -1607,7 +1610,9 @@ impl PredifiContract {
         Self::require_not_paused(&env);
         admin.require_auth();
         Self::require_admin_role(&env, &admin, "set_fee_bps")?;
-        assert!(Self::is_valid_fee_bps(fee_bps), "fee_bps exceeds 10000");
+        if !Self::is_valid_fee_bps(fee_bps) {
+            return Err(PredifiError::InvalidFeeBps);
+        }
         let mut config = Self::get_config(&env);
         config.fee_bps = fee_bps;
         env.storage().instance().set(&DataKey::Config, &config);
@@ -4183,7 +4188,7 @@ impl PredifiContract {
 
         for i in 0..tiers.len() {
             if let Some(tier) = tiers.get(i) {
-                if tier.fee_bps > 10_000 {
+                if tier.fee_bps > MAX_FEE_BPS {
                     return Err(PredifiError::InvalidFeeBps);
                 }
                 if i > 0 {

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -1483,6 +1483,47 @@ fn test_admin_can_set_fee_bps() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #93)")]
+fn test_init_rejects_fee_bps_above_100_percent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ac_id = env.register(dummy_access_control::DummyAccessControl, ());
+    let contract_id = env.register(PredifiContract, ());
+    let client = PredifiContractClient::new(&env, &contract_id);
+    let treasury = Address::generate(&env);
+
+    client.init(&ac_id, &treasury, &10_001u32, &0u64, &3600u64, &0u32);
+}
+
+#[test]
+fn test_set_fee_bps_rejects_above_100_percent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, _, _, _, _, _, _) = setup(&env);
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let result = client.try_set_fee_bps(&admin, &10_001u32);
+
+    assert_eq!(result, Err(Ok(PredifiError::InvalidFeeBps)));
+}
+
+#[test]
+fn test_set_fee_bps_allows_exactly_100_percent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, _, _, _, _, _, _) = setup(&env);
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    client.set_fee_bps(&admin, &10_000u32);
+    assert_eq!(client.get_fees().treasury_fee_bps, 10_000);
+}
+
+#[test]
 fn test_admin_can_set_treasury() {
     let env = Env::default();
     env.mock_all_auths();
@@ -10762,8 +10803,8 @@ fn test_update_price_feed_rejects_current_timestamp() {
         &feed_pair,
         &50_000_0000000i128,
         &100i128,
-        &now,           // timestamp == current ledger time
-        &(now + 3600),  // expires_at is fine
+        &now,          // timestamp == current ledger time
+        &(now + 3600), // expires_at is fine
     );
     assert_eq!(
         result,
@@ -10802,7 +10843,7 @@ fn test_update_price_feed_rejects_future_timestamp() {
         &feed_pair,
         &3_000_0000000i128,
         &50i128,
-        &(now + 1),     // timestamp is 1 second in the future
+        &(now + 1), // timestamp is 1 second in the future
         &(now + 3600),
     );
     assert_eq!(
@@ -10842,7 +10883,7 @@ fn test_update_price_feed_accepts_past_timestamp() {
         &feed_pair,
         &200_0000000i128,
         &10i128,
-        &(now - 1),     // 1 second in the past
+        &(now - 1), // 1 second in the past
         &(now + 3600),
     );
 }
@@ -11123,12 +11164,7 @@ fn test_init_oracle_rejects_zero_max_price_age() {
     let (ac_client, client, token_address, _, _, _, operator, _) = setup(&env);
     let admin = Address::generate(&env);
     ac_client.grant_role(&admin, &ROLE_ADMIN);
-    let result = client.try_init_oracle(
-        &admin,
-        &Address::generate(&env),
-        &0,
-        &100,
-    );
+    let result = client.try_init_oracle(&admin, &Address::generate(&env), &0, &100);
     assert_eq!(result, Err(Ok(PredifiError::InvalidData)));
 }
 
@@ -11139,12 +11175,7 @@ fn test_init_oracle_rejects_confidence_ratio_above_10000() {
     let (ac_client, client, _, _, _, _, _, _) = setup(&env);
     let admin = Address::generate(&env);
     ac_client.grant_role(&admin, &ROLE_ADMIN);
-    let result = client.try_init_oracle(
-        &admin,
-        &Address::generate(&env),
-        &300,
-        &10_001,
-    );
+    let result = client.try_init_oracle(&admin, &Address::generate(&env), &300, &10_001);
     assert_eq!(result, Err(Ok(PredifiError::InvalidFeeBps)));
 }
 


### PR DESCRIPTION
Fixes #1041.

## Summary
- add a shared `MAX_FEE_BPS` constant for the 100% protocol-fee boundary
- reject invalid initial `fee_bps` during `init` with `InvalidFeeBps`
- return `InvalidFeeBps` from `set_fee_bps` instead of using a raw assertion
- add tests for invalid init, invalid fee update, and the exact 10,000 bps boundary

## Validation
- `cargo fmt -p predifi-contract -- --check`
- `cargo test -p predifi-contract fee_bps` (9 passed)
- `git diff --check`

I also ran `cargo test -p predifi-contract`; the full suite has two unrelated failures on current `origin/main` and on this branch:
- `test_get_pool_stats_with_initial_liquidity` fails with `HostError: Error(Contract, #10)` because the creator has zero balance for initial liquidity transfer.
- `test_whitelisted_oracle_can_update_price_feed` fails with `HostError: Error(Contract, #90)` because the test submits timestamp `0` to price-feed update.
