### PR TITLE
Closes #1040 - docs: add usage instructions to build.sh

### DIFF
--- a/contract/build.sh
+++ b/contract/build.sh
@@ -1,4 +1,32 @@
 #!/bin/bash
+#
+# build.sh - Build and optimize PrediFi Soroban smart contracts
+#
+# DESCRIPTION:
+#   Compiles the Soroban contracts to WASM using the Soroban CLI, then
+#   optimizes the resulting WASM binaries with wasm-opt. The optimized
+#   files (suffixed with "_optimized.wasm") are the ones intended for
+#   deployment.
+#
+# USAGE:
+#   ./build.sh
+#
+# PREREQUISITES:
+#   - Rust toolchain with the appropriate wasm target installed
+#   - Soroban CLI (`soroban`) available on PATH
+#   - binaryen (`wasm-opt`) available on PATH:
+#       brew install binaryen        # macOS
+#       apt-get install binaryen     # Ubuntu/Debian
+#
+# OUTPUT:
+#   Original and optimized WASM files in:
+#     target/wasm32-unknown-unknown/release/
+#   Use the "_optimized.wasm" files for deployment.
+#
+# EXIT CODES:
+#   0  Build and optimization completed successfully
+#   1  wasm-opt not found (binaryen not installed)
+#
 set -e
 
 echo "Building Soroban contracts..."


### PR DESCRIPTION
## Description

Adds usage documentation to the top of `contracts/build.sh`. The script previously had no header explaining what it does or how to run it. This change adds a comment block covering the script's purpose, usage, prerequisites, output location, and exit codes — all derived from the script's existing behavior. No logic was changed.

Closes #1040

## Changes

- Added a documentation header to `contracts/build.sh` describing:
  - **Description** — builds Soroban contracts to WASM and optimizes them with `wasm-opt`
  - **Usage** — `./build.sh`
  - **Prerequisites** — Rust toolchain + wasm target, Soroban CLI, and binaryen (`wasm-opt`)
  - **Output** — original and optimized WASM files, noting the `_optimized.wasm` files are for deployment
  - **Exit codes** — `0` on success, `1` when `wasm-opt` is missing

## Acceptance Criteria

- [x] Feature/Optimization is implemented
- [x] Existing tests pass (comment-only change, no logic modified)
- [x] Code is clean and well-documented

## Notes

This is a documentation-only change — no executable lines were modified, so build and test behavior is unaffected.