### PR TITLE
fix: add oracle staleness test and test_all.sh script (#1025, #1026)

### DIFF
--- a/contract/contracts/predifi-contract/tests/price_feed_integration_test.rs
+++ b/contract/contracts/predifi-contract/tests/price_feed_integration_test.rs
@@ -139,3 +139,89 @@ fn test_price_based_pool_mock_resolution() {
     assert_eq!(pool.state, MarketState::Resolved);
     assert_eq!(pool.outcome, 1); // "Yes" outcome wins as 4100 > 4000
 }
+
+/// Verifies that `resolve_pool_from_price` rejects a price feed whose
+/// `expires_at` timestamp has already passed (i.e. stale oracle data).
+///
+/// The contract must return `PredifiError::InvalidPoolState` in this case,
+/// preventing any pool from being resolved with outdated price information.
+#[test]
+fn test_resolve_pool_rejects_stale_price_feed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    // Register dummy access control and predifi contracts
+    let ac_id = env.register(dummy_access_control::DummyAccessControl, ());
+    let ac_client = dummy_access_control::DummyAccessControlClient::new(&env, &ac_id);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+    ac_client.grant_role(&operator, &ROLE_OPERATOR);
+
+    let contract_id = env.register(PredifiContract, ());
+    let client = PredifiContractClient::new(&env, &contract_id);
+
+    client.init(&ac_id, &treasury, &0u32, &0u64, &3600u64, &0u32);
+
+    let token_address = Address::generate(&env);
+    client.add_token_to_whitelist(&admin, &token_address);
+    client.add_oracle(&admin, &oracle);
+
+    // Create a pool with end_time = 4000
+    let end_time = 4000u64;
+    let pool_id = client.create_pool(
+        &creator,
+        &end_time,
+        &token_address,
+        &2u32,
+        &symbol_short!("Crypto"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(&env, "Will ETH > $4000?"),
+            metadata_url: String::from_str(&env, "ipfs://..."),
+            min_stake: 100,
+            max_stake: 0,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0,
+            required_resolutions: 1,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "No"),
+                String::from_str(&env, "Yes"),
+            ],
+        },
+    );
+
+    // Set price condition: ETH > $4000
+    let asset = symbol_short!("ETH_USD");
+    let target_price = 4000_0000000i128;
+    client.set_price_condition(&operator, &pool_id, &asset, &target_price, &1u32, &100u32);
+
+    // Push a price feed at ledger time 1000 that expires at 2000 (before resolution time)
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.update_price_feed(
+        &oracle,
+        &asset,
+        &4100_0000000i128, // price above target
+        &100i128,
+        &999u64,  // strictly in the past
+        &2000u64, // expires at 2000 — will be stale by resolution time
+    );
+
+    // Fast-forward past end_time AND past expires_at — price is now stale
+    env.ledger().with_mut(|li| li.timestamp = 5000);
+
+    // Resolution must fail because the price feed has expired
+    let result = client.try_resolve_pool_from_price(&pool_id);
+    assert!(
+        result.is_err(),
+        "Expected error when resolving with stale price feed"
+    );
+}

--- a/contract/scripts/test_all.sh
+++ b/contract/scripts/test_all.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# test_all.sh
+# ---------------------------------------------------------------------------
+# Runs the full test suite for every crate in the PrediFi workspace
+# sequentially, then prints a consolidated pass/fail summary.
+#
+# Usage (run from the `contract/` workspace root):
+#   bash scripts/test_all.sh
+#
+# Exit codes:
+#   0 – all crates passed
+#   1 – one or more crates failed
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Crates to test in order (relative to WORKSPACE_ROOT)
+CRATES=(
+  "contracts/predifi-errors"
+  "contracts/access-control"
+  "contracts/predifi-contract"
+)
+
+PASS=()
+FAIL=()
+
+echo "══════════════════════════════════════════════"
+echo "  PrediFi – Test All Crates"
+echo "  Workspace: ${WORKSPACE_ROOT}"
+echo "══════════════════════════════════════════════"
+echo ""
+
+for crate in "${CRATES[@]}"; do
+  crate_path="${WORKSPACE_ROOT}/${crate}"
+  crate_name="$(basename "${crate}")"
+
+  echo "──────────────────────────────────────────────"
+  echo "  Testing: ${crate_name}"
+  echo "──────────────────────────────────────────────"
+
+  if cargo test --manifest-path "${crate_path}/Cargo.toml" 2>&1; then
+    PASS+=("${crate_name}")
+    echo "✅  ${crate_name} PASSED"
+  else
+    FAIL+=("${crate_name}")
+    echo "❌  ${crate_name} FAILED"
+  fi
+
+  echo ""
+done
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo "══════════════════════════════════════════════"
+echo "  Summary"
+echo "══════════════════════════════════════════════"
+echo "  Passed : ${#PASS[@]} / $(( ${#PASS[@]} + ${#FAIL[@]} ))"
+
+for name in "${PASS[@]}"; do
+  echo "    ✅  ${name}"
+done
+
+if [[ ${#FAIL[@]} -gt 0 ]]; then
+  echo "  Failed : ${#FAIL[@]}"
+  for name in "${FAIL[@]}"; do
+    echo "    ❌  ${name}"
+  done
+  echo ""
+  echo "❌  Some tests FAILED. See output above for details."
+  echo "══════════════════════════════════════════════"
+  exit 1
+fi
+
+echo ""
+echo "✅  All crates passed."
+echo "══════════════════════════════════════════════"
+exit 0


### PR DESCRIPTION
## Issue #1026 — Add test for oracle price staleness

### Problem
There was no test verifying that `resolve_pool_from_price` rejects resolution when the oracle price feed has expired (i.e. the current ledger time is past the feed's `expires_at` timestamp). Without this test, the staleness guard in `lib.rs` (line ~4167) was untested, leaving a critical safety path uncovered.

### What was done
Added `test_resolve_pool_rejects_stale_price_feed` to:
  contract/contracts/predifi-contract/tests/price_feed_integration_test.rs

### How it works
1. Registers a `DummyAccessControl` and `PredifiContract` using the same mock pattern as the existing `test_price_based_pool_mock_resolution` test in the same file.
2. Creates a prediction pool with `end_time = 4000`.
3. Sets a price condition (ETH > $4000) on the pool.
4. At ledger time 1000, pushes a price feed via `update_price_feed` with `expires_at = 2000` — intentionally short-lived.
5. Fast-forwards the ledger to time 5000 (past both `end_time` and `expires_at`), making the price feed stale.
6. Calls `try_resolve_pool_from_price` and asserts the result is an error, confirming the contract correctly rejects stale oracle data (the contract returns `PredifiError::InvalidPoolState` in this path).

Closes #1026

---

## Issue #1025 — Create scripts/test_all.sh

### Problem
There was no single script to run the test suite across all three workspace crates (`predifi-errors`, `access-control`, `predifi-contract`) in one command. Developers had to either run `cargo test --workspace` (which gives no per-crate pass/fail summary) or manually cd into each crate directory.

### What was done
Created:
  contract/scripts/test_all.sh

### How it works
1. Resolves the workspace root relative to the script's own location, so it works regardless of the caller's working directory.
2. Iterates a `CRATES` array in dependency order: - contracts/predifi-errors - contracts/access-control - contracts/predifi-contract
3. For each crate, runs `cargo test --manifest-path <crate>/Cargo.toml` and captures whether it passed or failed.
4. After all crates finish, prints a consolidated summary table showing ✅/❌ per crate and the overall pass count.
5. Exits with code 0 if all crates pass, or code 1 if any fail — making it safe to use in CI pipelines.
6. The script is marked executable (chmod +x) and uses `#!/usr/bin/env bash` with `set -euo pipefail` for safety.

Closes #1025

# Description

Provide a brief summary of the changes and the motivation behind them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or internal tool improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Screenshots / Recordings

> [!IMPORTANT]
> **A screenshot or screen recording is REQUIRED for all frontend/UI changes.**
> Please paste your screenshots or recordings below.

<!-- Paste screenshots/recordings here -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
