### PR TITLE
Strict CORS Origin Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Local PR draft — not part of the repository history
+PULL_REQUEST.md
+
+# Kiro IDE workspace metadata
+.kiro/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,12 @@ APP_HOST=0.0.0.0
 APP_PORT=3000
 RUST_LOG=info
 
+# CORS — comma-separated list of allowed origins.
+# Each entry must be a valid http:// or https:// origin (scheme + host + optional port).
+# Paths, query strings, fragments, wildcards, and the 'null' origin are not permitted.
+# Defaults to: http://localhost:3000,http://localhost:5173,https://predifi.app
+# CORS_ALLOWED_ORIGINS=https://predifi.app,https://admin.predifi.app
+
 # PostgreSQL
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/predifi
 DB_MAX_CONNECTIONS=10

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -14,6 +14,13 @@ const DEFAULT_TREASURY_FEE_BPS: u32 = 300;
 const DEFAULT_REFERRAL_FEE_BPS: u32 = 5000;
 const DEFAULT_REDIS_URL: &str = "redis://localhost:6379";
 
+/// Origins allowed by default when `CORS_ALLOWED_ORIGINS` is not set.
+pub const DEFAULT_CORS_ORIGINS: &[&str] = &[
+    "http://localhost:3000",
+    "http://localhost:5173",
+    "https://predifi.app",
+];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     pub host: String,
@@ -30,6 +37,15 @@ pub struct Config {
     pub stellar_rpc_url: String,
     pub sentry_dsn: Option<String>,
     pub redis_url: String,
+    /// Validated list of origins permitted by the CORS policy.
+    ///
+    /// Loaded from the `CORS_ALLOWED_ORIGINS` environment variable as a
+    /// comma-separated list of origins (e.g. `https://app.example.com,https://admin.example.com`).
+    /// Each entry must be a valid `http://` or `https://` origin — scheme + host (+ optional port)
+    /// with no path, query string, or fragment.  Invalid entries are rejected at startup.
+    ///
+    /// Falls back to [`DEFAULT_CORS_ORIGINS`] when the variable is absent.
+    pub cors_allowed_origins: Vec<String>,
 }
 
 impl Config {
@@ -67,6 +83,9 @@ impl Config {
         let sentry_dsn = vars.get("SENTRY_DSN").cloned();
         let redis_url = get_string(vars, "REDIS_URL", DEFAULT_REDIS_URL);
 
+        // Parse and strictly validate CORS origins.
+        let cors_allowed_origins = parse_cors_origins(vars)?;
+
         if db_min_connections > db_max_connections {
             return Err(ConfigError::InvalidValue {
                 key: "DB_MIN_CONNECTIONS",
@@ -92,6 +111,7 @@ impl Config {
             stellar_rpc_url,
             sentry_dsn,
             redis_url,
+            cors_allowed_origins,
         })
     }
 
@@ -116,6 +136,10 @@ impl Config {
             stellar_rpc_url: String::from(DEFAULT_STELLAR_RPC_URL),
             sentry_dsn: None,
             redis_url: String::from(DEFAULT_REDIS_URL),
+            cors_allowed_origins: DEFAULT_CORS_ORIGINS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
         }
     }
 }
@@ -147,6 +171,139 @@ impl fmt::Display for ConfigError {
 }
 
 impl std::error::Error for ConfigError {}
+
+/// Parse and strictly validate the `CORS_ALLOWED_ORIGINS` environment variable.
+///
+/// The value must be a comma-separated list of origins.  Each origin must:
+/// - Use the `http` or `https` scheme.
+/// - Contain a non-empty host.
+/// - Have **no** path component other than an optional trailing slash on the root.
+/// - Have **no** query string or fragment.
+///
+/// Returns the default origins when the variable is absent.
+fn parse_cors_origins(vars: &HashMap<String, String>) -> Result<Vec<String>, ConfigError> {
+    let raw = match vars.get("CORS_ALLOWED_ORIGINS") {
+        Some(v) => v.clone(),
+        None => {
+            return Ok(DEFAULT_CORS_ORIGINS
+                .iter()
+                .map(|s| s.to_string())
+                .collect());
+        }
+    };
+
+    let origins: Vec<String> = raw
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if origins.is_empty() {
+        return Err(ConfigError::InvalidValue {
+            key: "CORS_ALLOWED_ORIGINS",
+            reason: String::from("must contain at least one origin"),
+        });
+    }
+
+    for origin in &origins {
+        validate_cors_origin(origin)?;
+    }
+
+    Ok(origins)
+}
+
+/// Validate a single CORS origin string.
+///
+/// A valid origin is `scheme://host` or `scheme://host:port` where:
+/// - `scheme` is `http` or `https`
+/// - `host` is non-empty
+/// - There is no path (other than an empty path or bare `/`), no query, and no fragment.
+fn validate_cors_origin(origin: &str) -> Result<(), ConfigError> {
+    // Reject wildcards and the special `null` origin outright.
+    if origin == "*" || origin.eq_ignore_ascii_case("null") {
+        return Err(ConfigError::InvalidValue {
+            key: "CORS_ALLOWED_ORIGINS",
+            reason: format!("'{}' is not a valid origin — wildcards and 'null' are not permitted", origin),
+        });
+    }
+
+    // Split off the scheme.
+    let rest = if let Some(r) = origin.strip_prefix("https://") {
+        r
+    } else if let Some(r) = origin.strip_prefix("http://") {
+        r
+    } else {
+        return Err(ConfigError::InvalidValue {
+            key: "CORS_ALLOWED_ORIGINS",
+            reason: format!(
+                "'{}' is not a valid origin — must start with 'http://' or 'https://'",
+                origin
+            ),
+        });
+    };
+
+    // Reject fragments and query strings.
+    if rest.contains('#') || rest.contains('?') {
+        return Err(ConfigError::InvalidValue {
+            key: "CORS_ALLOWED_ORIGINS",
+            reason: format!(
+                "'{}' is not a valid origin — must not contain a query string or fragment",
+                origin
+            ),
+        });
+    }
+
+    // Split host[:port] from any path component.
+    let (authority, path) = match rest.find('/') {
+        Some(idx) => (&rest[..idx], &rest[idx..]),
+        None => (rest, ""),
+    };
+
+    // A path other than "" or "/" is not allowed in an origin.
+    if !path.is_empty() && path != "/" {
+        return Err(ConfigError::InvalidValue {
+            key: "CORS_ALLOWED_ORIGINS",
+            reason: format!(
+                "'{}' is not a valid origin — must not contain a path component",
+                origin
+            ),
+        });
+    }
+
+    // The host part must be non-empty.
+    let host = match authority.rfind(':') {
+        // Possible port — strip it and validate.
+        Some(colon_idx) => {
+            let port_str = &authority[colon_idx + 1..];
+            // Only treat it as a port if it's all digits; otherwise it's part of an IPv6 address.
+            if port_str.chars().all(|c| c.is_ascii_digit()) {
+                let port: u32 = port_str.parse().unwrap_or(u32::MAX);
+                if port > 65535 {
+                    return Err(ConfigError::InvalidValue {
+                        key: "CORS_ALLOWED_ORIGINS",
+                        reason: format!(
+                            "'{}' is not a valid origin — port {} is out of range (0-65535)",
+                            origin, port_str
+                        ),
+                    });
+                }
+                &authority[..colon_idx]
+            } else {
+                authority
+            }
+        }
+        None => authority,
+    };
+
+    if host.is_empty() {
+        return Err(ConfigError::InvalidValue {
+            key: "CORS_ALLOWED_ORIGINS",
+            reason: format!("'{}' is not a valid origin — host must not be empty", origin),
+        });
+    }
+
+    Ok(())
+}
 
 fn get_string(vars: &HashMap<String, String>, key: &'static str, default: &str) -> String {
     vars.get(key)
@@ -270,6 +427,179 @@ mod tests {
                     ..
                 }
             ),
+            "unexpected error: {error}"
+        );
+    }
+
+    // ── CORS origin validation ────────────────────────────────────────────────
+
+    #[test]
+    fn cors_defaults_when_env_absent() {
+        let vars = HashMap::new();
+        let config = Config::from_map(&vars).expect("defaults should be valid");
+        let expected: Vec<String> = DEFAULT_CORS_ORIGINS.iter().map(|s| s.to_string()).collect();
+        assert_eq!(config.cors_allowed_origins, expected);
+    }
+
+    #[test]
+    fn cors_accepts_valid_https_origin() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("https://example.com"),
+        )]);
+        let config = Config::from_map(&vars).expect("valid https origin should be accepted");
+        assert_eq!(config.cors_allowed_origins, vec!["https://example.com"]);
+    }
+
+    #[test]
+    fn cors_accepts_valid_http_origin_with_port() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("http://localhost:5173"),
+        )]);
+        let config = Config::from_map(&vars).expect("http origin with port should be accepted");
+        assert_eq!(config.cors_allowed_origins, vec!["http://localhost:5173"]);
+    }
+
+    #[test]
+    fn cors_accepts_multiple_valid_origins() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("https://app.example.com,https://admin.example.com"),
+        )]);
+        let config = Config::from_map(&vars).expect("multiple valid origins should be accepted");
+        assert_eq!(
+            config.cors_allowed_origins,
+            vec!["https://app.example.com", "https://admin.example.com"]
+        );
+    }
+
+    #[test]
+    fn cors_trims_whitespace_around_origins() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("  https://app.example.com , https://admin.example.com  "),
+        )]);
+        let config = Config::from_map(&vars).expect("whitespace should be trimmed");
+        assert_eq!(
+            config.cors_allowed_origins,
+            vec!["https://app.example.com", "https://admin.example.com"]
+        );
+    }
+
+    #[test]
+    fn cors_rejects_wildcard() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("*"),
+        )]);
+        let error = Config::from_map(&vars).expect_err("wildcard must be rejected");
+        assert!(
+            matches!(error, ConfigError::InvalidValue { key: "CORS_ALLOWED_ORIGINS", .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn cors_rejects_null_origin() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("null"),
+        )]);
+        let error = Config::from_map(&vars).expect_err("null origin must be rejected");
+        assert!(
+            matches!(error, ConfigError::InvalidValue { key: "CORS_ALLOWED_ORIGINS", .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn cors_rejects_missing_scheme() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("example.com"),
+        )]);
+        let error = Config::from_map(&vars).expect_err("origin without scheme must be rejected");
+        assert!(
+            matches!(error, ConfigError::InvalidValue { key: "CORS_ALLOWED_ORIGINS", .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn cors_rejects_ftp_scheme() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("ftp://example.com"),
+        )]);
+        let error = Config::from_map(&vars).expect_err("ftp scheme must be rejected");
+        assert!(
+            matches!(error, ConfigError::InvalidValue { key: "CORS_ALLOWED_ORIGINS", .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn cors_rejects_origin_with_path() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("https://example.com/api"),
+        )]);
+        let error = Config::from_map(&vars).expect_err("origin with path must be rejected");
+        assert!(
+            matches!(error, ConfigError::InvalidValue { key: "CORS_ALLOWED_ORIGINS", .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn cors_rejects_origin_with_query_string() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("https://example.com?foo=bar"),
+        )]);
+        let error = Config::from_map(&vars).expect_err("origin with query string must be rejected");
+        assert!(
+            matches!(error, ConfigError::InvalidValue { key: "CORS_ALLOWED_ORIGINS", .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn cors_rejects_origin_with_fragment() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("https://example.com#section"),
+        )]);
+        let error = Config::from_map(&vars).expect_err("origin with fragment must be rejected");
+        assert!(
+            matches!(error, ConfigError::InvalidValue { key: "CORS_ALLOWED_ORIGINS", .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn cors_rejects_port_out_of_range() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("https://example.com:99999"),
+        )]);
+        let error = Config::from_map(&vars).expect_err("port > 65535 must be rejected");
+        assert!(
+            matches!(error, ConfigError::InvalidValue { key: "CORS_ALLOWED_ORIGINS", .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn cors_rejects_empty_list() {
+        let vars = HashMap::from([(
+            String::from("CORS_ALLOWED_ORIGINS"),
+            String::from("   "),
+        )]);
+        let error = Config::from_map(&vars).expect_err("empty origin list must be rejected");
+        assert!(
+            matches!(error, ConfigError::InvalidValue { key: "CORS_ALLOWED_ORIGINS", .. }),
             "unexpected error: {error}"
         );
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -32,16 +32,17 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
-/// Allowed frontend origins for CORS.
-const ALLOWED_ORIGINS: &[&str] = &[
-    "http://localhost:3000",
-    "http://localhost:5173",
-    "https://predifi.app",
-];
-
-/// Build the CORS middleware layer.
-pub fn build_cors() -> CorsLayer {
-    let origins: Vec<HeaderValue> = ALLOWED_ORIGINS
+/// Build the CORS middleware layer from the validated origin list in `config`.
+///
+/// Only the origins listed in [`Config::cors_allowed_origins`] are permitted.
+/// The list is validated at startup (see `config::parse_cors_origins`), so any
+/// entry that reaches this function is already a well-formed `http://` or
+/// `https://` origin.  Entries that cannot be parsed into a [`HeaderValue`] are
+/// silently skipped (this should never happen in practice given the prior
+/// validation).
+pub fn build_cors(config: &Config) -> CorsLayer {
+    let origins: Vec<HeaderValue> = config
+        .cors_allowed_origins
         .iter()
         .filter_map(|origin| origin.parse().ok())
         .collect();
@@ -259,7 +260,7 @@ pub fn build_router(config: Config, cache: price_cache::PriceCache, redis: redis
         .layer(GovernorLayer {
             config: governor_conf,
         })
-        .layer(build_cors())
+        .layer(build_cors(&config))
         .layer(LoggingLayer)
 }
 
@@ -313,7 +314,7 @@ pub fn build_router_with_db(
         .layer(GovernorLayer {
             config: governor_conf,
         })
-        .layer(build_cors())
+        .layer(build_cors(&config))
         .layer(LoggingLayer)
 }
 

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -232,6 +232,137 @@ async fn cors_handles_preflight_request() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
+/// Requests from an origin that is NOT in the allow-list must not receive an
+/// `Access-Control-Allow-Origin` header.  The request itself is still served
+/// (CORS is enforced by the browser, not the server), but the missing header
+/// tells the browser to block the response.
+#[tokio::test]
+async fn cors_rejects_disallowed_origin() {
+    let response = build_router(
+        Config::default_for_test(),
+        PriceCache::new(),
+        RedisCache::disabled(),
+        crate::ws::EventBus::new(),
+    )
+    .oneshot(
+        Request::builder()
+            .method(Method::GET)
+            .uri("/health")
+            .header(header::ORIGIN, "https://evil.example.com")
+            .body(axum::body::Body::empty())
+            .expect("failed to build request"),
+    )
+    .await
+    .expect("request failed");
+
+    let allow_origin = response
+        .headers()
+        .get("access-control-allow-origin")
+        .and_then(|v| v.to_str().ok());
+
+    assert_eq!(
+        allow_origin, None,
+        "disallowed origin must not receive an Access-Control-Allow-Origin header"
+    );
+}
+
+/// Preflight from a disallowed origin must not receive an
+/// `Access-Control-Allow-Origin` header.
+#[tokio::test]
+async fn cors_rejects_disallowed_origin_preflight() {
+    let response = build_router(
+        Config::default_for_test(),
+        PriceCache::new(),
+        RedisCache::disabled(),
+        crate::ws::EventBus::new(),
+    )
+    .oneshot(
+        Request::builder()
+            .method(Method::OPTIONS)
+            .uri("/health")
+            .header(header::ORIGIN, "https://evil.example.com")
+            .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+            .body(axum::body::Body::empty())
+            .expect("failed to build request"),
+    )
+    .await
+    .expect("request failed");
+
+    let allow_origin = response
+        .headers()
+        .get("access-control-allow-origin")
+        .and_then(|v| v.to_str().ok());
+
+    assert_eq!(
+        allow_origin, None,
+        "preflight from a disallowed origin must not receive an Access-Control-Allow-Origin header"
+    );
+}
+
+/// A custom origin list supplied via Config is respected.
+#[tokio::test]
+async fn cors_respects_custom_origin_list() {
+    let mut config = Config::default_for_test();
+    config.cors_allowed_origins = vec![String::from("https://custom.example.com")];
+
+    // The custom origin should be allowed.
+    let response = build_router(
+        config.clone(),
+        PriceCache::new(),
+        RedisCache::disabled(),
+        crate::ws::EventBus::new(),
+    )
+    .oneshot(
+        Request::builder()
+            .method(Method::GET)
+            .uri("/health")
+            .header(header::ORIGIN, "https://custom.example.com")
+            .body(axum::body::Body::empty())
+            .expect("failed to build request"),
+    )
+    .await
+    .expect("request failed");
+
+    let allow_origin = response
+        .headers()
+        .get("access-control-allow-origin")
+        .and_then(|v| v.to_str().ok());
+
+    assert_eq!(
+        allow_origin,
+        Some("https://custom.example.com"),
+        "custom allowed origin should receive the CORS header"
+    );
+
+    // The default localhost origin should now be blocked.
+    let response2 = build_router(
+        config,
+        PriceCache::new(),
+        RedisCache::disabled(),
+        crate::ws::EventBus::new(),
+    )
+    .oneshot(
+        Request::builder()
+            .method(Method::GET)
+            .uri("/health")
+            .header(header::ORIGIN, "http://localhost:5173")
+            .body(axum::body::Body::empty())
+            .expect("failed to build request"),
+    )
+    .await
+    .expect("request failed");
+
+    let allow_origin2 = response2
+        .headers()
+        .get("access-control-allow-origin")
+        .and_then(|v| v.to_str().ok());
+
+    assert_eq!(
+        allow_origin2, None,
+        "origin not in the custom list must be blocked"
+    );
+}
+
 /// Verify that the rate limiter returns 429 Too Many Requests after exceeding the limit.
 #[tokio::test]
 async fn rate_limiting_returns_429_after_burst() {


### PR DESCRIPTION
# Strict CORS Origin Validation

Closes #990

## Description

CORS origins were previously hardcoded as a compile-time constant in `main.rs`
with no runtime configurability and no test coverage for the rejection path.
This change moves origin management into `Config`, adds strict validation at
startup, and makes the allowed list configurable via an environment variable.

### What changed

| File | Change |
|------|--------|
| `backend/src/config.rs` | Added `cors_allowed_origins` field, `parse_cors_origins()`, and `validate_cors_origin()` |
| `backend/src/main.rs` | Removed hardcoded `ALLOWED_ORIGINS` const; `build_cors()` now accepts `&Config` |
| `backend/src/tests.rs` | Added 4 new integration tests covering allowed, disallowed, preflight, and custom-list scenarios |
| `backend/.env.example` | Documented `CORS_ALLOWED_ORIGINS` with format rules and default value |
| `.gitignore` (root) | Added `PULL_REQUEST.md` and `.kiro/` |

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or internal tool improvement

## Motivation

The previous implementation had two gaps:

1. **No runtime configurability** — adding or removing an allowed origin required
   a code change and a redeploy.
2. **No rejection-path tests** — there was nothing to prevent a future refactor
   from accidentally enabling wildcard CORS.

## Implementation Details

### Strict validation (`validate_cors_origin`)

Each origin in `CORS_ALLOWED_ORIGINS` is validated at server startup against
these rules:

- Must start with `http://` or `https://` — no other schemes accepted.
- Must have a non-empty host.
- Must **not** contain a path component (other than a bare `/`).
- Must **not** contain a query string or fragment.
- Port, if present, must be in the range `0–65535`.
- The wildcard `*` and the special `null` origin are explicitly rejected.

Invalid entries cause the server to exit at startup with a clear error message
rather than silently serving with a broken CORS policy.

### Runtime configuration

```
# .env  (comma-separated, whitespace around commas is trimmed)
CORS_ALLOWED_ORIGINS=https://predifi.app,https://admin.predifi.app
```

When the variable is absent the server falls back to the original three
defaults: `http://localhost:3000`, `http://localhost:5173`,
`https://predifi.app`.

## How Has This Been Tested?

### Config-layer unit tests (13 new tests in `config.rs`)

| Test | Asserts |
|------|---------|
| `cors_defaults_when_env_absent` | Falls back to the three default origins |
| `cors_accepts_valid_https_origin` | Plain `https://` origin accepted |
| `cors_accepts_valid_http_origin_with_port` | `http://host:port` accepted |
| `cors_accepts_multiple_valid_origins` | Comma-separated list parsed correctly |
| `cors_trims_whitespace_around_origins` | Whitespace around commas stripped |
| `cors_rejects_wildcard` | `*` returns `InvalidValue` error |
| `cors_rejects_null_origin` | `null` returns `InvalidValue` error |
| `cors_rejects_missing_scheme` | Bare hostname rejected |
| `cors_rejects_ftp_scheme` | Non-http/https scheme rejected |
| `cors_rejects_origin_with_path` | Path component rejected |
| `cors_rejects_origin_with_query_string` | Query string rejected |
| `cors_rejects_origin_with_fragment` | Fragment rejected |
| `cors_rejects_port_out_of_range` | Port > 65535 rejected |
| `cors_rejects_empty_list` | Whitespace-only value rejected |

### Router integration tests (4 new tests in `tests.rs`)

| Test | Asserts |
|------|---------|
| `cors_rejects_disallowed_origin` | No `Access-Control-Allow-Origin` header for unknown origin |
| `cors_rejects_disallowed_origin_preflight` | Same for OPTIONS preflight |
| `cors_respects_custom_origin_list` | Custom list in Config is used by middleware |
| *(existing)* `cors_allows_allowed_origin` | Still passes — allowed origin gets the header |
| *(existing)* `cors_handles_preflight_request` | Still passes — preflight returns 200 |

All existing tests continue to pass without modification.

## Screenshots / Recordings

> N/A — backend-only change, no UI impact.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
