### PR TITLE
feat(storage): Migrate resolution voting to temporary storage

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -570,12 +570,15 @@ pub enum DataKey {
     /// Category pool index: `CatPoolIx(category, index)` -> `u64` (pool_id)
     CatPoolIx(Symbol, u32),
 
-    // ── Resolution voting ────────────────────────────────────────────────────
-    /// Tracks if an oracle/operator has already voted: `ResVote(pool_id, voter_address)` -> `()`
+    // ── Resolution voting (TEMPORARY STORAGE) ────────────────────────────────
+    /// Tracks if an oracle/operator has already voted (temporary): `ResVote(pool_id, voter_address)` -> `()`
+    /// Stored in temporary storage as it's only needed during resolution process.
     ResVote(u64, Address),
-    /// Vote count for a specific outcome: `ResVoteCt(pool_id, outcome)` -> `u32`
+    /// Vote count for a specific outcome (temporary): `ResVoteCt(pool_id, outcome)` -> `u32`
+    /// Stored in temporary storage as it's only needed during resolution process.
     ResVoteCt(u64, u32),
-    /// Total number of votes cast for a pool: `ResTotal(pool_id)` -> `u32`
+    /// Total number of votes cast for a pool (temporary): `ResTotal(pool_id)` -> `u32`
+    /// Stored in temporary storage as it's only needed during resolution process.
     ResTotal(u64),
 
     // ── Referrals ────────────────────────────────────────────────────────────
@@ -1295,6 +1298,12 @@ impl PredifiContract {
     fn extend_persistent(env: &Env, key: &DataKey) {
         env.storage()
             .persistent()
+            .extend_ttl(key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    }
+
+    fn extend_temporary(env: &Env, key: &DataKey) {
+        env.storage()
+            .temporary()
             .extend_ttl(key, BUMP_THRESHOLD, BUMP_AMOUNT);
     }
 
@@ -2717,7 +2726,7 @@ impl PredifiContract {
 
         // Check if this operator has already voted for this pool
         let vote_key = DataKey::ResVote(pool_id, operator.clone());
-        if env.storage().persistent().has(&vote_key) {
+        if env.storage().temporary().has(&vote_key) {
             log!(
                 &env,
                 "resolve_pool rejected: operator already voted",
@@ -2728,35 +2737,35 @@ impl PredifiContract {
             return Err(PredifiError::OracleAlreadyVoted); // Reusing error code for operators
         }
 
-        // Record the operator's vote
-        env.storage().persistent().set(&vote_key, &outcome);
-        Self::extend_persistent(&env, &vote_key);
+        // Record the operator's vote in temporary storage
+        env.storage().temporary().set(&vote_key, &outcome);
+        Self::extend_temporary(&env, &vote_key);
 
         // Increment total number of votes cast for this pool
         let total_votes_key = DataKey::ResTotal(pool_id);
         let total_votes: u32 = env
             .storage()
-            .persistent()
+            .temporary()
             .get(&total_votes_key)
             .unwrap_or(0);
         let new_total_votes = total_votes + 1;
         env.storage()
-            .persistent()
+            .temporary()
             .set(&total_votes_key, &new_total_votes);
-        Self::extend_persistent(&env, &total_votes_key);
+        Self::extend_temporary(&env, &total_votes_key);
 
         // Increment specific outcome vote count
         let outcome_votes_key = DataKey::ResVoteCt(pool_id, outcome);
         let outcome_votes: u32 = env
             .storage()
-            .persistent()
+            .temporary()
             .get(&outcome_votes_key)
             .unwrap_or(0);
         let new_outcome_votes = outcome_votes + 1;
         env.storage()
-            .persistent()
+            .temporary()
             .set(&outcome_votes_key, &new_outcome_votes);
-        Self::extend_persistent(&env, &outcome_votes_key);
+        Self::extend_temporary(&env, &outcome_votes_key);
 
         // Emit a ResolutionVoteCastEvent for observability
         ResolutionVoteCastEvent {
@@ -2775,7 +2784,7 @@ impl PredifiContract {
                     continue;
                 }
                 let other_key = DataKey::ResVoteCt(pool_id, i);
-                if env.storage().persistent().has(&other_key) {
+                if env.storage().temporary().has(&other_key) {
                     ResolutionConflictEvent {
                         pool_id,
                         oracle: operator.clone(),
@@ -4485,39 +4494,39 @@ impl OracleCallback for PredifiContract {
         // --- Multi-oracle Voting Logic ---
 
         let vote_key = DataKey::ResVote(pool_id, oracle.clone());
-        if env.storage().persistent().has(&vote_key) {
+        if env.storage().temporary().has(&vote_key) {
             return Err(PredifiError::OracleAlreadyVoted);
         }
 
-        // Record the oracle's vote
-        env.storage().persistent().set(&vote_key, &outcome);
-        Self::extend_persistent(&env, &vote_key);
+        // Record the oracle's vote in temporary storage
+        env.storage().temporary().set(&vote_key, &outcome);
+        Self::extend_temporary(&env, &vote_key);
 
         // Increment total number of votes cast for this pool
         let total_votes_key = DataKey::ResTotal(pool_id);
         let total_votes: u32 = env
             .storage()
-            .persistent()
+            .temporary()
             .get(&total_votes_key)
             .unwrap_or(0);
         let new_total_votes = total_votes + 1;
         env.storage()
-            .persistent()
+            .temporary()
             .set(&total_votes_key, &new_total_votes);
-        Self::extend_persistent(&env, &total_votes_key);
+        Self::extend_temporary(&env, &total_votes_key);
 
         // Increment specific outcome vote count
         let outcome_votes_key = DataKey::ResVoteCt(pool_id, outcome);
         let outcome_votes: u32 = env
             .storage()
-            .persistent()
+            .temporary()
             .get(&outcome_votes_key)
             .unwrap_or(0);
         let new_outcome_votes = outcome_votes + 1;
         env.storage()
-            .persistent()
+            .temporary()
             .set(&outcome_votes_key, &new_outcome_votes);
-        Self::extend_persistent(&env, &outcome_votes_key);
+        Self::extend_temporary(&env, &outcome_votes_key);
 
         // Detect conflicts: if there are ANY votes for a different outcome
         if new_total_votes > new_outcome_votes {
@@ -4527,7 +4536,7 @@ impl OracleCallback for PredifiContract {
                     continue;
                 }
                 let other_key = DataKey::ResVoteCt(pool_id, i);
-                if env.storage().persistent().has(&other_key) {
+                if env.storage().temporary().has(&other_key) {
                     ResolutionConflictEvent {
                         pool_id,
                         oracle: oracle.clone(),

--- a/contract/contracts/predifi-contract/src/storage_test.rs
+++ b/contract/contracts/predifi-contract/src/storage_test.rs
@@ -356,6 +356,44 @@ mod tests {
         });
     }
 
+    /// Resolution voting keys must be in temporary storage only.
+    #[test]
+    fn test_resolution_voting_keys_in_temporary_storage() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, contract_id, _) = setup(&env);
+
+        env.as_contract(&contract_id, || {
+            // Initially, no votes should exist
+            assert!(
+                !env.storage().temporary().has(&DataKey::ResVote(1, Address::generate(&env))),
+                "ResVote must not exist before voting"
+            );
+            assert!(
+                !env.storage().temporary().has(&DataKey::ResVoteCt(1, 0)),
+                "ResVoteCt must not exist before voting"
+            );
+            assert!(
+                !env.storage().temporary().has(&DataKey::ResTotal(1)),
+                "ResTotal must not exist before voting"
+            );
+
+            // These keys must NOT be in persistent or instance storage
+            assert!(
+                !env.storage().persistent().has(&DataKey::ResVote(1, Address::generate(&env))),
+                "ResVote must not be in persistent storage"
+            );
+            assert!(
+                !env.storage().instance().has(&DataKey::ResVoteCt(1, 0)),
+                "ResVoteCt must not be in instance storage"
+            );
+            assert!(
+                !env.storage().instance().has(&DataKey::ResTotal(1)),
+                "ResTotal must not be in instance storage"
+            );
+        });
+    }
+
     // ── Isolation tests ──────────────────────────────────────────────────────
 
     /// Different pool IDs must produce distinct PriceCondition keys.


### PR DESCRIPTION
- Move ResVote, ResVoteCt, ResTotal keys from persistent to temporary storage
- Add extend_temporary() helper for TTL management
- Update resolve_pool() and oracle_resolve() to use temporary storage
- Add comprehensive storage tier tests for voting keys
- Reduces persistent storage footprint and gas costs

This optimization is based on the fact that resolution voting data is only needed during the resolution phase and doesn't require persistence after the pool is resolved.

Closes #1006

# Description

Provide a brief summary of the changes and the motivation behind them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or internal tool improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Screenshots / Recordings

> [!IMPORTANT]
> **A screenshot or screen recording is REQUIRED for all frontend/UI changes.**
> Please paste your screenshots or recordings below.

<!-- Paste screenshots/recordings here -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


Closes #1006