### PR TITLE
fix: reject zero-amount stakes in place_prediction (#1019)

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -3033,7 +3033,10 @@ impl PredifiContract {
     ) {
         Self::require_not_paused(&env);
         user.require_auth();
-        assert!(amount > 0, "amount must be positive");
+        // Reject zero or negative stake amounts.
+        if amount <= 0 {
+            soroban_sdk::panic_with_error!(&env, PredifiError::InvalidAmount);
+        }
 
         // Validate: amount must meet the global protocol minimum stake
         let global_min_stake = Self::get_config(&env).min_stake;

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -5863,6 +5863,47 @@ fn test_create_pool_accepts_maximum_options_count() {
     client.place_prediction(&user, &pool_id, &100, &99, &None, &None);
 }
 
+/// Placing a prediction with a zero amount must be rejected with InvalidAmount (#42).
+#[test]
+#[should_panic(expected = "Error(Contract, #42)")]
+fn test_place_prediction_rejects_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, token_admin_client, _, _, creator) = setup(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &Symbol::new(&env, "Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(&env, "Zero amount test"),
+            metadata_url: String::from_str(&env, "ipfs://zero-amount"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0,
+            min_total_stake: 1,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: soroban_sdk::vec![
+                &env,
+                String::from_str(&env, "Outcome 0"),
+                String::from_str(&env, "Outcome 1"),
+            ],
+        },
+    );
+
+    let user = Address::generate(&env);
+    token_admin_client.mint(&user, &1000);
+    // amount of 0 must be rejected
+    client.place_prediction(&user, &pool_id, &0, &0, &None, &None);
+}
+
 /// Placing a prediction with outcome >= options_count must be rejected.
 /// This tests the limit enforcement in update_outcome_stake.
 #[test]


### PR DESCRIPTION
> ## Description

Closes #1019. place_prediction was using a plain assert!(amount > 0, "amount must be positive") which panics with a raw string. This replaces it with panic_with_error!(&env, PredifiError::InvalidAmount) so callers receive a typed, inspectable 
contract error (Error(Contract, #42)), consistent with every other validation in the function.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added test_place_prediction_rejects_zero_amount in test.rs:

rust
#[test]
#[should_panic(expected = "Error(Contract, #42)")]
fn test_place_prediction_rejects_zero_amount() { ... }


The test creates a pool, mints tokens to a user, then calls place_prediction with amount = 0 and asserts the contract panics with PredifiError::InvalidAmount (code 42).

To reproduce locally:
bash
cd contract
cargo test test_place_prediction_rejects_zero_amount


## Screenshots / Recordings

N/A — no frontend changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules