### PR TITLE
Add pool creation boundary tests

### DIFF
--- a/contract/contracts/access-control/src/lib.rs
+++ b/contract/contracts/access-control/src/lib.rs
@@ -262,7 +262,7 @@ impl AccessControl {
             .persistent()
             .set(&DataKey::Role(admin.clone(), Role::Admin), &());
 
-        AdminInitEvent { admin }.publish(&env);
+        AdminInitEvent { admin }.publish(env);
     }
 
     /// Gets the current admin address.
@@ -460,12 +460,12 @@ impl AccessControl {
     ) -> Result<(), PrediFiError> {
         admin_caller.require_auth();
 
-        let current_admin = Self::get_admin(env.clone());
-        if admin_caller != current_admin {
+        let current_admin = Self::get_admin(env);
+        if admin_caller != &current_admin {
             return Err(PrediFiError::Unauthorized);
         }
 
-        Self::apply_admin_transfer(env, current_admin.clone(), new_admin.clone());
+        Self::apply_admin_transfer(env, current_admin.clone(), &new_admin);
 
         AdminTransferredEvent {
             admin: current_admin,
@@ -518,7 +518,7 @@ impl AccessControl {
         }
 
         let current_admin = Self::get_admin(env);
-        Self::apply_admin_transfer(env, current_admin.clone(), new_admin.clone());
+        Self::apply_admin_transfer(env, current_admin.clone(), &new_admin);
 
         AdminTransferredEvent {
             admin: current_admin,
@@ -561,8 +561,7 @@ impl AccessControl {
             Role::Moderator,
             Role::Oracle,
             Role::User,
-        ]
-        {
+        ] {
             let key = DataKey::Role(user.clone(), role.clone());
             if env.storage().persistent().has(&key) {
                 env.storage().persistent().remove(&key);

--- a/contract/contracts/predifi-contract/src/edge_case_tests.rs
+++ b/contract/contracts/predifi-contract/src/edge_case_tests.rs
@@ -140,7 +140,7 @@ fn two_outcome_config(env: &Env) -> PoolConfig {
 ///
 /// The contract asserts `end_time > current_time`, so equality is invalid.
 #[test]
-#[should_panic(expected = "end_time must be greater than current time")]
+#[should_panic(expected = "end_time must be in the future")]
 fn test_create_pool_end_time_equals_current_time_is_rejected() {
     let env = Env::default();
     let (client, token_client, _, _) = setup(&env);
@@ -162,7 +162,7 @@ fn test_create_pool_end_time_equals_current_time_is_rejected() {
 /// Creating a pool with `end_time == current_time + min_pool_duration - 1`
 /// (one second short of the minimum) must also be rejected.
 #[test]
-#[should_panic(expected = "pool duration too short")]
+#[should_panic(expected = "end_time must be at least min_pool_duration in the future")]
 fn test_create_pool_end_time_below_min_duration_is_rejected() {
     let env = Env::default();
     let (client, token_client, _, _) = setup(&env);
@@ -185,7 +185,7 @@ fn test_create_pool_end_time_below_min_duration_is_rejected() {
 /// Placing a prediction at the exact moment `current_time == pool.end_time`
 /// must be rejected — the betting window is half-open `[creation, end_time)`.
 #[test]
-#[should_panic(expected = "betting window closed")]
+#[should_panic(expected = "Pool has ended")]
 fn test_place_prediction_at_exact_end_time_is_rejected() {
     let env = Env::default();
     let (client, token_client, token_admin_client, _) = setup(&env);

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -21,7 +21,7 @@ mod test_utils;
 
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, log, symbol_short, token,
-    Address, BytesN, Env, IntoVal, String, Symbol, Vec,
+    Address, BytesN, Env, IntoVal, String, Symbol, SymbolStr, TryFromVal, Vec,
 };
 
 pub use constants::*;
@@ -1181,16 +1181,18 @@ impl PredifiContract {
         Err(PredifiError::InvalidData)
     }
 
-    fn validate_referral_code(code: &Symbol) -> Result<(), PredifiError> {
-        let code_str = code.as_str();
-        let len = code_str.len();
+    fn validate_referral_code(env: &Env, code: &Symbol) -> Result<(), PredifiError> {
+        let code_str = SymbolStr::try_from_val(env, &code.to_symbol_val())
+            .map_err(|_| PredifiError::InvalidData)?;
+        let code_bytes: &[u8] = code_str.as_ref();
+        let len = code_bytes.len();
 
-        if len < 6 || len > 12 {
+        if !(6..=12).contains(&len) {
             return Err(PredifiError::InvalidData);
         }
 
-        for ch in code_str.chars() {
-            if !matches!(ch, 'A'..='Z' | '0'..='9') {
+        for byte in code_bytes {
+            if !matches!(*byte, b'A'..=b'Z' | b'0'..=b'9') {
                 return Err(PredifiError::InvalidData);
             }
         }
@@ -1216,7 +1218,10 @@ impl PredifiContract {
     fn is_valid_state_transition(current: MarketState, next: MarketState) -> bool {
         matches!(
             (current, next),
-            (MarketState::Active, MarketState::Resolved | MarketState::Canceled)
+            (
+                MarketState::Active,
+                MarketState::Resolved | MarketState::Canceled
+            )
         )
     }
 
@@ -2407,7 +2412,7 @@ impl PredifiContract {
         assert!(config.max_total_stake >= 0, "max_total_stake must be >= 0");
 
         if let Some(ref whitelist_key) = config.whitelist_key {
-            if let Err(e) = Self::validate_referral_code(whitelist_key) {
+            if let Err(e) = Self::validate_referral_code(&env, whitelist_key) {
                 soroban_sdk::panic_with_error!(&env, e);
             }
         }
@@ -2766,11 +2771,7 @@ impl PredifiContract {
 
         // Increment total number of votes cast for this pool
         let total_votes_key = DataKey::ResTotal(pool_id);
-        let total_votes: u32 = env
-            .storage()
-            .temporary()
-            .get(&total_votes_key)
-            .unwrap_or(0);
+        let total_votes: u32 = env.storage().temporary().get(&total_votes_key).unwrap_or(0);
         let new_total_votes = total_votes + 1;
         env.storage()
             .temporary()
@@ -3077,7 +3078,7 @@ impl PredifiContract {
         }
 
         if let Some(ref invite_key) = invite_key {
-            if let Err(e) = Self::validate_referral_code(invite_key) {
+            if let Err(e) = Self::validate_referral_code(&env, invite_key) {
                 soroban_sdk::panic_with_error!(&env, e);
             }
         }
@@ -4536,11 +4537,7 @@ impl OracleCallback for PredifiContract {
 
         // Increment total number of votes cast for this pool
         let total_votes_key = DataKey::ResTotal(pool_id);
-        let total_votes: u32 = env
-            .storage()
-            .temporary()
-            .get(&total_votes_key)
-            .unwrap_or(0);
+        let total_votes: u32 = env.storage().temporary().get(&total_votes_key).unwrap_or(0);
         let new_total_votes = total_votes + 1;
         env.storage()
             .temporary()

--- a/contract/contracts/predifi-contract/src/storage_test.rs
+++ b/contract/contracts/predifi-contract/src/storage_test.rs
@@ -366,7 +366,9 @@ mod tests {
         env.as_contract(&contract_id, || {
             // Initially, no votes should exist
             assert!(
-                !env.storage().temporary().has(&DataKey::ResVote(1, Address::generate(&env))),
+                !env.storage()
+                    .temporary()
+                    .has(&DataKey::ResVote(1, Address::generate(&env))),
                 "ResVote must not exist before voting"
             );
             assert!(
@@ -380,7 +382,9 @@ mod tests {
 
             // These keys must NOT be in persistent or instance storage
             assert!(
-                !env.storage().persistent().has(&DataKey::ResVote(1, Address::generate(&env))),
+                !env.storage()
+                    .persistent()
+                    .has(&DataKey::ResVote(1, Address::generate(&env))),
                 "ResVote must not be in persistent storage"
             );
             assert!(

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -343,7 +343,7 @@ fn test_create_pool_rejects_referral_code_too_short() {
     let (_, client, token_address, _, _, _, _, creator) = setup(&env);
     let now = env.ledger().timestamp();
 
-    let result = std::panic::catch_unwind(|| {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.create_pool(
             &creator,
             &(now + 3600u64),
@@ -369,7 +369,7 @@ fn test_create_pool_rejects_referral_code_too_short() {
                 ],
             },
         );
-    });
+    }));
 
     assert!(result.is_err());
 }
@@ -382,7 +382,7 @@ fn test_create_pool_rejects_referral_code_too_long() {
     let (_, client, token_address, _, _, _, _, creator) = setup(&env);
     let now = env.ledger().timestamp();
 
-    let result = std::panic::catch_unwind(|| {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.create_pool(
             &creator,
             &(now + 3600u64),
@@ -408,7 +408,7 @@ fn test_create_pool_rejects_referral_code_too_long() {
                 ],
             },
         );
-    });
+    }));
 
     assert!(result.is_err());
 }
@@ -421,7 +421,7 @@ fn test_create_pool_rejects_referral_code_lowercase() {
     let (_, client, token_address, _, _, _, _, creator) = setup(&env);
     let now = env.ledger().timestamp();
 
-    let result = std::panic::catch_unwind(|| {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.create_pool(
             &creator,
             &(now + 3600u64),
@@ -447,7 +447,7 @@ fn test_create_pool_rejects_referral_code_lowercase() {
                 ],
             },
         );
-    });
+    }));
 
     assert!(result.is_err());
 }
@@ -460,7 +460,7 @@ fn test_create_pool_rejects_referral_code_special_characters() {
     let (_, client, token_address, _, _, _, _, creator) = setup(&env);
     let now = env.ledger().timestamp();
 
-    let result = std::panic::catch_unwind(|| {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.create_pool(
             &creator,
             &(now + 3600u64),
@@ -486,7 +486,7 @@ fn test_create_pool_rejects_referral_code_special_characters() {
                 ],
             },
         );
-    });
+    }));
 
     assert!(result.is_err());
 }
@@ -527,7 +527,7 @@ fn test_place_prediction_rejects_invalid_invite_key() {
         },
     );
 
-    let result = std::panic::catch_unwind(|| {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.place_prediction(
             &user,
             &pool_id,
@@ -536,7 +536,7 @@ fn test_place_prediction_rejects_invalid_invite_key() {
             &None,
             &Some(Symbol::new(&env, "AbC123")),
         );
-    });
+    }));
 
     assert!(result.is_err());
 }
@@ -4285,7 +4285,6 @@ fn test_pool_resolved_event_emitted_on_resolution() {
     assert!(found, "PoolResolvedEvent not found in emitted events");
 }
 
-
 #[test]
 fn test_mark_pool_ready() {
     let env = Env::default();
@@ -5764,6 +5763,108 @@ fn test_resolution_then_new_pool_state_isolation() {
 
 // ── Boundary values in all validation logic ───────────────────────────────────
 
+fn repeated_outcome_descriptions(env: &Env, count: u32) -> soroban_sdk::Vec<String> {
+    let mut outcomes = soroban_sdk::Vec::new(env);
+    for _ in 0..count {
+        outcomes.push_back(String::from_str(env, "Outcome"));
+    }
+    outcomes
+}
+
+/// The lowest valid values for pool creation parameters must be accepted.
+#[test]
+fn test_create_pool_accepts_minimum_boundary_parameters() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, _, _, _, creator) = setup(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &DEFAULT_MIN_POOL_DURATION,
+        &token_address,
+        &2u32,
+        &Symbol::new(&env, "Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(&env, ""),
+            metadata_url: String::from_str(&env, ""),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0i128,
+            min_total_stake: 1i128,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: repeated_outcome_descriptions(&env, 2),
+        },
+    );
+
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.end_time, DEFAULT_MIN_POOL_DURATION);
+    assert_eq!(pool.options_count, 2);
+    assert_eq!(pool.min_stake, 1);
+    assert_eq!(pool.max_stake, 0);
+    assert_eq!(pool.min_total_stake, 1);
+    assert_eq!(pool.max_total_stake, 0);
+    assert_eq!(pool.initial_liquidity, 0);
+    assert_eq!(pool.required_resolutions, 1);
+    assert_eq!(pool.total_stake, 0);
+    assert_eq!(pool.outcome_descriptions.len(), 2);
+}
+
+/// The highest valid pool duration, option count, metadata sizes, stake caps,
+/// and initial liquidity ceiling must be accepted together.
+#[test]
+fn test_create_pool_accepts_maximum_boundary_parameters() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, token_admin_client, _, _, creator) = setup(&env);
+    token_admin_client.mint(&creator, &MAX_INITIAL_LIQUIDITY);
+
+    let max_description_bytes = [b'D'; 256];
+    let max_metadata_bytes = [b'M'; 512];
+    let max_description = core::str::from_utf8(&max_description_bytes).unwrap();
+    let max_metadata = core::str::from_utf8(&max_metadata_bytes).unwrap();
+
+    let pool_id = client.create_pool(
+        &creator,
+        &MAX_POOL_DURATION,
+        &token_address,
+        &MAX_OPTIONS_COUNT,
+        &Symbol::new(&env, "Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(&env, max_description),
+            metadata_url: String::from_str(&env, max_metadata),
+            min_stake: MAX_INITIAL_LIQUIDITY,
+            max_stake: MAX_INITIAL_LIQUIDITY,
+            max_total_stake: MAX_INITIAL_LIQUIDITY,
+            min_total_stake: MAX_INITIAL_LIQUIDITY,
+            initial_liquidity: MAX_INITIAL_LIQUIDITY,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: repeated_outcome_descriptions(&env, MAX_OPTIONS_COUNT),
+        },
+    );
+
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.end_time, MAX_POOL_DURATION);
+    assert_eq!(pool.options_count, MAX_OPTIONS_COUNT);
+    assert_eq!(pool.description.len(), 256);
+    assert_eq!(pool.metadata_url.len(), 512);
+    assert_eq!(pool.min_stake, MAX_INITIAL_LIQUIDITY);
+    assert_eq!(pool.max_stake, MAX_INITIAL_LIQUIDITY);
+    assert_eq!(pool.min_total_stake, MAX_INITIAL_LIQUIDITY);
+    assert_eq!(pool.max_total_stake, MAX_INITIAL_LIQUIDITY);
+    assert_eq!(pool.initial_liquidity, MAX_INITIAL_LIQUIDITY);
+    assert_eq!(pool.total_stake, MAX_INITIAL_LIQUIDITY);
+    assert_eq!(pool.outcome_descriptions.len(), MAX_OPTIONS_COUNT);
+}
+
 /// min_stake == 0 must be rejected.
 #[test]
 #[should_panic(expected = "min_stake must be greater than zero")]
@@ -5796,6 +5897,102 @@ fn test_create_pool_rejects_zero_min_stake() {
                 String::from_str(&env, "Outcome 0"),
                 String::from_str(&env, "Outcome 1"),
             ],
+        },
+    );
+}
+
+/// required_resolutions == 0 must be rejected.
+#[test]
+#[should_panic(expected = "required_resolutions must be at least 1")]
+fn test_create_pool_rejects_zero_required_resolutions() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, _, _, _, creator) = setup(&env);
+
+    client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &Symbol::new(&env, "Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(&env, "Zero required resolutions"),
+            metadata_url: String::from_str(&env, "ipfs://zero-required-resolutions"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0i128,
+            min_total_stake: 1i128,
+            initial_liquidity: 0i128,
+            required_resolutions: 0u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: repeated_outcome_descriptions(&env, 2),
+        },
+    );
+}
+
+/// Negative max_total_stake values must be rejected; zero remains the unlimited sentinel.
+#[test]
+#[should_panic(expected = "max_total_stake must be >= 0")]
+fn test_create_pool_rejects_negative_max_total_stake() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, _, _, _, creator) = setup(&env);
+
+    client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &Symbol::new(&env, "Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(&env, "Negative max total stake"),
+            metadata_url: String::from_str(&env, "ipfs://negative-max-total"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: -1i128,
+            min_total_stake: 1i128,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: repeated_outcome_descriptions(&env, 2),
+        },
+    );
+}
+
+/// Initial liquidity one unit above MAX_INITIAL_LIQUIDITY must be rejected.
+#[test]
+#[should_panic(expected = "initial_liquidity exceeds maximum allowed value")]
+fn test_create_pool_rejects_initial_liquidity_above_maximum() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, client, token_address, _, _, _, _, creator) = setup(&env);
+
+    client.create_pool(
+        &creator,
+        &100_000u64,
+        &token_address,
+        &2u32,
+        &Symbol::new(&env, "Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(&env, "Excess initial liquidity"),
+            metadata_url: String::from_str(&env, "ipfs://excess-liquidity"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0i128,
+            min_total_stake: 1i128,
+            initial_liquidity: MAX_INITIAL_LIQUIDITY + 1,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: repeated_outcome_descriptions(&env, 2),
         },
     );
 }
@@ -8080,7 +8277,7 @@ fn test_get_pool_config_private_pool_with_whitelist_key() {
 
     let (_, client, token_address, _, _, _, _, creator) = setup(&env);
 
-    let whitelist_key = symbol_short!("secret");
+    let whitelist_key = symbol_short!("SECRET");
     let config = PoolConfig {
         start_time: 0,
         description: String::from_str(&env, "Private pool"),
@@ -8212,7 +8409,7 @@ fn test_get_pool_config_multiple_pools_independent() {
             initial_liquidity: 50i128,
             required_resolutions: 1u32,
             private: true,
-            whitelist_key: Some(Symbol::new(&env, "secret")),
+            whitelist_key: Some(Symbol::new(&env, "SECRET")),
             outcome_descriptions: soroban_sdk::vec![
                 &env,
                 String::from_str(&env, "Option 1"),
@@ -8367,7 +8564,7 @@ fn test_create_pool_with_zero_max_total_stake_is_unlimited() {
 /// predictions, then verify that an additional prediction is rejected with
 /// `MaxTotalStakeExceeded`.
 #[test]
-#[should_panic(expected = "MaxTotalStakeExceeded")]
+#[should_panic(expected = "Error(Contract, #104)")]
 fn test_place_prediction_rejects_when_max_total_stake_exceeded() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary
- Added unit tests covering minimum and maximum valid pool creation parameters.
- Added rejection coverage for invalid boundary values: zero required resolutions, negative max total stake, and initial liquidity above the allowed maximum.
- Updated stale test expectations and formatting/lint issues required for the workspace checks to pass.

## Tests
- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

closes #1007 