### PR TITLE
feat: implement code splitting for recharts via dynamic imports (#948)

### DIFF
--- a/frontend/components/dashboard/StakedChart.tsx
+++ b/frontend/components/dashboard/StakedChart.tsx
@@ -1,106 +1,101 @@
 "use client";
 
-import { Bar, BarChart, ResponsiveContainer, XAxis, Tooltip, Cell } from "recharts";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+/**
+ * StakedChart
+ *
+ * Shell component that owns the card layout and loading state.
+ * The recharts rendering logic lives in StakedChartRenderer, which is loaded
+ * via next/dynamic so that the recharts library is placed in a separate JS
+ * chunk and never included in the initial page bundle.
+ *
+ * Code-splitting strategy:
+ *   - This file (StakedChart) is itself already lazily loaded by the dashboard
+ *     page via next/dynamic.
+ *   - StakedChartRenderer (and therefore recharts) is a second lazy boundary
+ *     nested inside, ensuring recharts is isolated in its own chunk and only
+ *     fetched when the chart card is about to mount.
+ *   - ssr: false prevents a server-render attempt of the canvas/SVG output,
+ *     which avoids hydration mismatches for this client-only library.
+ */
+
+import dynamic from "next/dynamic";
 import { ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
-const data = [
-    { name: "JAN", value: 35000 },
-    { name: "FEB", value: 45000 },
-    { name: "MAR", value: 35000 },
-    { name: "APR", value: 30000 },
-    { name: "MAY", value: 65000, active: true },
-    { name: "JUN", value: 15000 },
-    { name: "JUL", value: 50000 },
-    { name: "AUG", value: 25000 },
-    { name: "SEP", value: 45000 },
-    { name: "OCT", value: 75000 },
-    { name: "NOV", value: 45000 },
-    { name: "DEC", value: 60000 },
-];
-
-// eslint-disable-next-line
-const CustomTooltip = ({ active, payload, label }: any) => {
-    if (active && payload && payload.length) {
-        return (
-            <div className="bg-zinc-900 border border-white/10 p-2 rounded-lg shadow-xl">
-                <p className="text-zinc-400 text-xs mb-1">{label}</p>
-                <p className="text-white font-bold font-mono">
-                    ${(payload[0].value / 1000).toFixed(0)}k
-                </p>
-            </div>
-        );
-    }
-    return null;
-};
+/**
+ * Dynamically import the recharts renderer so the library is code-split into
+ * its own chunk.  The loading fallback mirrors the bar-chart skeleton shown
+ * during the outer lazy load so the transition is seamless.
+ */
+const StakedChartRenderer = dynamic(
+  () =>
+    import("@/components/dashboard/StakedChartRenderer").then(
+      (mod) => mod.StakedChartRenderer
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-end gap-2 px-2 pb-2">
+        {[55, 70, 55, 45, 90, 25, 75, 40, 70, 100, 70, 85].map((h, i) => (
+          <Skeleton
+            key={i}
+            className="flex-1 rounded-t-sm"
+            style={{ height: `${h}%` }}
+          />
+        ))}
+      </div>
+    ),
+  }
+);
 
 interface StakedChartProps {
-    isLoading?: boolean;
+  isLoading?: boolean;
 }
 
 export function StakedChart({ isLoading = false }: StakedChartProps) {
-    if (isLoading) {
-        return (
-            <Card className="bg-[#121212] border-none text-white h-full">
-                <CardHeader className="flex flex-row items-center justify-between pb-2">
-                    <Skeleton className="h-5 w-28" />
-                    <div className="flex items-center gap-2">
-                        <Skeleton className="h-7 w-12 rounded-full" />
-                        <Skeleton className="h-8 w-28 rounded-full" />
-                    </div>
-                </CardHeader>
-                <CardContent className="h-[240px] mt-4 flex items-end gap-2 px-6">
-                    {[55, 70, 55, 45, 90, 25, 75, 40, 70, 100, 70, 85].map((h, i) => (
-                        <Skeleton
-                            key={i}
-                            className="flex-1 rounded-t-sm"
-                            style={{ height: `${h}%` }}
-                        />
-                    ))}
-                </CardContent>
-            </Card>
-        );
-    }
-
+  if (isLoading) {
     return (
-        <Card className="bg-[#121212] border-none text-white h-full">
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-                <CardTitle className="text-lg font-medium">Total staked</CardTitle>
-                <div className="flex items-center gap-2">
-                    <div className="bg-zinc-800/50 px-3 py-1.5 rounded-full text-xs font-medium text-white/80">
-                        23k
-                    </div>
-                    <Button className="bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-white hover:bg-zinc-800 h-8 rounded-full text-xs">
-                        This month
-                        <ChevronDown className="ml-2 w-3 h-3" />
-                    </Button>
-                </div>
-            </CardHeader>
-            <CardContent className="h-[240px] w-full mt-4">
-                <ResponsiveContainer width="100%" height="100%">
-                    <BarChart data={data}>
-                        <XAxis
-                            dataKey="name"
-                            axisLine={false}
-                            tickLine={false}
-                            tick={{ fill: '#525252', fontSize: 10 }}
-                            dy={10}
-                        />
-                        <Tooltip content={<CustomTooltip />} cursor={{ fill: 'transparent' }} />
-                        <Bar dataKey="value" radius={[4, 4, 4, 4]}>
-                            {data.map((entry, index) => (
-                                <Cell
-                                    key={`cell-${index}`}
-                                    fill={entry.active ? '#37B7C3' : '#262626'}
-                                    className="transition-all duration-300 hover:opacity-80"
-                                />
-                            ))}
-                        </Bar>
-                    </BarChart>
-                </ResponsiveContainer>
-            </CardContent>
-        </Card>
+      <Card className="bg-[#121212] border-none text-white h-full">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <Skeleton className="h-5 w-28" />
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-7 w-12 rounded-full" />
+            <Skeleton className="h-8 w-28 rounded-full" />
+          </div>
+        </CardHeader>
+        <CardContent className="h-[240px] mt-4 flex items-end gap-2 px-6">
+          {[55, 70, 55, 45, 90, 25, 75, 40, 70, 100, 70, 85].map((h, i) => (
+            <Skeleton
+              key={i}
+              className="flex-1 rounded-t-sm"
+              style={{ height: `${h}%` }}
+            />
+          ))}
+        </CardContent>
+      </Card>
     );
+  }
+
+  return (
+    <Card className="bg-[#121212] border-none text-white h-full">
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-lg font-medium">Total staked</CardTitle>
+        <div className="flex items-center gap-2">
+          <div className="bg-zinc-800/50 px-3 py-1.5 rounded-full text-xs font-medium text-white/80">
+            23k
+          </div>
+          <Button className="bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-white hover:bg-zinc-800 h-8 rounded-full text-xs">
+            This month
+            <ChevronDown className="ml-2 w-3 h-3" />
+          </Button>
+        </div>
+      </CardHeader>
+      {/* StakedChartRenderer is loaded lazily — recharts is not in this chunk */}
+      <CardContent className="h-[240px] w-full mt-4">
+        <StakedChartRenderer />
+      </CardContent>
+    </Card>
+  );
 }

--- a/frontend/components/dashboard/StakedChartRenderer.tsx
+++ b/frontend/components/dashboard/StakedChartRenderer.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * StakedChartRenderer
+ *
+ * This module is intentionally isolated so that the recharts library is placed
+ * in its own JavaScript chunk by the bundler.  It is loaded exclusively via a
+ * dynamic import inside StakedChart.tsx, which means recharts is never part of
+ * the initial page bundle and is only fetched when the chart is about to be
+ * rendered.
+ */
+
+import {
+  Bar,
+  BarChart,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+} from "recharts";
+
+const data = [
+  { name: "JAN", value: 35000 },
+  { name: "FEB", value: 45000 },
+  { name: "MAR", value: 35000 },
+  { name: "APR", value: 30000 },
+  { name: "MAY", value: 65000, active: true },
+  { name: "JUN", value: 15000 },
+  { name: "JUL", value: 50000 },
+  { name: "AUG", value: 25000 },
+  { name: "SEP", value: 45000 },
+  { name: "OCT", value: 75000 },
+  { name: "NOV", value: 45000 },
+  { name: "DEC", value: 60000 },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-zinc-900 border border-white/10 p-2 rounded-lg shadow-xl">
+        <p className="text-zinc-400 text-xs mb-1">{label}</p>
+        <p className="text-white font-bold font-mono">
+          ${(payload[0].value / 1000).toFixed(0)}k
+        </p>
+      </div>
+    );
+  }
+  return null;
+};
+
+/**
+ * The raw recharts bar chart.  Rendered inside a fixed-height container
+ * supplied by the parent StakedChart card.
+ */
+export function StakedChartRenderer() {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data}>
+        <XAxis
+          dataKey="name"
+          axisLine={false}
+          tickLine={false}
+          tick={{ fill: "#525252", fontSize: 10 }}
+          dy={10}
+        />
+        <Tooltip content={<CustomTooltip />} cursor={{ fill: "transparent" }} />
+        <Bar dataKey="value" radius={[4, 4, 4, 4]}>
+          {data.map((entry, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={entry.active ? "#37B7C3" : "#262626"}
+              className="transition-all duration-300 hover:opacity-80"
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
Extracts the recharts rendering logic into a dedicated StakedChartRenderer component and loads it via next/dynamic with ssr: false inside StakedChart. This places the recharts library in its own JS chunk, keeping it out of the initial bundle and preventing it from blocking the main thread.

Closes #948
