### PR TITLE
feat: cache prediction pool data with SWR 

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,6 +18,21 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `NEXT_PUBLIC_API_BASE_URL` | `http://localhost:8080` | Base URL of the PrediFi backend API used by the data layer in `lib/api`. |
+
+## Data fetching & caching
+
+Server data is fetched through [SWR](https://swr.vercel.app). Global defaults
+live in `components/providers/SWRProvider.tsx` and are tuned for the app's
+largely-static data (responses are cached and deduplicated; no revalidation on
+window focus or reconnect). Prediction pool data is exposed via the
+`usePools()` hook (`lib/hooks/usePools.ts`), backed by the typed client in
+`lib/api/pools.ts`.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { DM_Mono } from "next/font/google";
 import "./globals.css";
+import { SWRProvider } from "@/components/providers/SWRProvider";
 
 const dmMono = DM_Mono({
   subsets: ["latin"],
@@ -85,7 +86,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`antialiased text-sm ${dmMono.variable}`}>
-        {children}
+        <SWRProvider>{children}</SWRProvider>
       </body>
     </html>
   );

--- a/frontend/components/dashboard/PoolsList.tsx
+++ b/frontend/components/dashboard/PoolsList.tsx
@@ -1,12 +1,57 @@
+"use client";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { usePools } from "@/lib/hooks/usePools";
+import type { Pool } from "@/lib/api/pools";
 
 interface PoolsListProps {
+  /**
+   * Force the loading skeleton regardless of fetch state — handy for demos and
+   * visual tests. When omitted, the live SWR loading state is used.
+   */
   isLoading?: boolean;
 }
 
-export function PoolsList({ isLoading = false }: PoolsListProps) {
-  if (isLoading) {
+/** Compact, human-readable rendering of a stake amount. */
+function formatStake(totalStake: number): string {
+  return totalStake.toLocaleString();
+}
+
+/** A single row in the created-pools list. */
+function PoolRow({ pool }: { pool: Pool }) {
+  return (
+    <div className="flex items-center justify-between p-3 rounded-lg bg-zinc-900/50">
+      <div className="space-y-1 min-w-0">
+        <p className="text-sm font-medium text-white truncate">{pool.name}</p>
+        <p className="text-xs text-zinc-500">
+          {pool.category} · {formatStake(pool.total_stake)} {pool.token}
+        </p>
+      </div>
+      <span className="shrink-0 text-xs font-medium px-3 py-1 rounded-full bg-zinc-800 text-zinc-300 capitalize">
+        {pool.state}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * PoolsList — the dashboard's "Created Pools" card.
+ *
+ * Pool data is fetched through {@link usePools}, which caches the response via
+ * SWR. Because pool metadata is largely static, repeated mounts (e.g. navigating
+ * back to the dashboard) render instantly from cache instead of refetching.
+ */
+export function PoolsList({ isLoading: isLoadingOverride }: PoolsListProps = {}) {
+  // "Created pools" are static metadata — newest active pools, cached by SWR.
+  const { pools, isLoading, isError, refresh } = usePools({
+    status: "active",
+    sort_by: "new",
+  });
+
+  const showSkeleton = isLoadingOverride ?? isLoading;
+
+  if (showSkeleton) {
     return (
       <Card className="bg-[#121212] border-none text-white h-full min-h-[400px]">
         <CardHeader>
@@ -33,10 +78,28 @@ export function PoolsList({ isLoading = false }: PoolsListProps) {
         <CardTitle className="text-lg font-medium">Created Pools</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="flex items-center justify-center h-[300px] text-zinc-600">
-          {/* Empty state placeholder */}
-          <p>No pools created yet!</p>
-        </div>
+        {isError ? (
+          <div className="flex flex-col items-center justify-center h-[300px] gap-3 text-zinc-500">
+            <p>Couldn&apos;t load pools.</p>
+            <button
+              onClick={refresh}
+              className="text-sm font-medium text-[#37B7C3] hover:underline"
+            >
+              Try again
+            </button>
+          </div>
+        ) : pools.length === 0 ? (
+          <div className="flex items-center justify-center h-[300px] text-zinc-600">
+            {/* Empty state placeholder */}
+            <p>No pools created yet!</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {pools.map((pool) => (
+              <PoolRow key={pool.pool_id} pool={pool} />
+            ))}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/components/providers/SWRProvider.tsx
+++ b/frontend/components/providers/SWRProvider.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { SWRConfig } from "swr";
+import type { ReactNode } from "react";
+
+/**
+ * SWRProvider — app-wide SWR configuration.
+ *
+ * Defaults are tuned for the largely-static data PrediFi displays (notably
+ * prediction-pool metadata): responses are cached and deduplicated, and we
+ * avoid aggressive revalidation that would refetch data the user already has.
+ * Individual hooks can still override any of these per call.
+ */
+export function SWRProvider({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig
+      value={{
+        // Treat fetched data as fresh for 60s: identical keys requested within
+        // this window reuse the in-flight/last response instead of refetching.
+        dedupingInterval: 60_000,
+        // Static data doesn't change while the user tabs away and back.
+        revalidateOnFocus: false,
+        // Avoid a refetch storm when connectivity flaps.
+        revalidateOnReconnect: false,
+        // Keep showing the previous page's data while a new query loads.
+        keepPreviousData: true,
+        // Retry transient network/server errors a couple of times.
+        errorRetryCount: 2,
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+}

--- a/frontend/lib/api/pools.ts
+++ b/frontend/lib/api/pools.ts
@@ -1,0 +1,105 @@
+/**
+ * Prediction pool API client.
+ *
+ * Thin, typed wrapper around the PrediFi backend's `GET /api/v1/pools`
+ * endpoint. The exported {@link fetchPools} function is used as the SWR
+ * fetcher (see `lib/hooks/usePools.ts`) so that pool data is cached and
+ * deduplicated across the app.
+ *
+ * The shapes here mirror the backend OpenAPI schema (`PoolDoc` /
+ * `PoolsResponse` in `backend/src/openapi.rs`).
+ */
+
+/**
+ * Base URL of the PrediFi backend API.
+ *
+ * Configurable per environment via `NEXT_PUBLIC_API_BASE_URL`; falls back to
+ * the local backend default so the dashboard works out of the box in dev.
+ */
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+
+/** A single prediction-market pool. */
+export interface Pool {
+  pool_id: number;
+  name: string;
+  category: string;
+  /** Total amount staked across the pool, in the token's base units. */
+  total_stake: number;
+  /** Pool close time as a Unix timestamp (seconds). */
+  end_time: number;
+  created_at: string;
+  state: string;
+  creator: string;
+  token: string;
+  /** Settled outcome, or `null` while the pool is still open. */
+  result: string | null;
+}
+
+/** Response body of `GET /api/v1/pools`. */
+export interface PoolsResponse {
+  pools: Pool[];
+  total: number;
+  limit: number;
+  offset: number;
+  status: string;
+  category?: string | null;
+  sort_by: string;
+}
+
+/** Filters accepted by `GET /api/v1/pools`. */
+export interface PoolsQuery {
+  /** Sort order. Defaults to `"new"` on the backend. */
+  sort_by?: "popular" | "ending_soon" | "new";
+  /** Category filter, e.g. `"Sports"` or `"Crypto"`. */
+  category?: string;
+  /** Lifecycle filter. Defaults to `"active"` on the backend. */
+  status?: "active" | "closed" | "settled";
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Build the request URL for a pools query.
+ *
+ * The returned string doubles as the SWR cache key: two calls with equal
+ * filters produce an identical URL and therefore share one cache entry.
+ */
+export function poolsUrl(query: PoolsQuery = {}): string {
+  const params = new URLSearchParams();
+  if (query.sort_by) params.set("sort_by", query.sort_by);
+  if (query.category) params.set("category", query.category);
+  if (query.status) params.set("status", query.status);
+  if (query.limit != null) params.set("limit", String(query.limit));
+  if (query.offset != null) params.set("offset", String(query.offset));
+
+  const qs = params.toString();
+  return `${API_BASE_URL}/api/v1/pools${qs ? `?${qs}` : ""}`;
+}
+
+/** Error raised when the pools endpoint responds with a non-2xx status. */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/**
+ * SWR fetcher for pool data.
+ *
+ * @param url - A URL produced by {@link poolsUrl}.
+ * @throws {ApiError} When the response status is not 2xx.
+ */
+export async function fetchPools(url: string): Promise<PoolsResponse> {
+  const res = await fetch(url, { headers: { Accept: "application/json" } });
+
+  if (!res.ok) {
+    throw new ApiError(`Failed to load pools (HTTP ${res.status})`, res.status);
+  }
+
+  return (await res.json()) as PoolsResponse;
+}

--- a/frontend/lib/hooks/usePools.ts
+++ b/frontend/lib/hooks/usePools.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import useSWR from "swr";
+import {
+  fetchPools,
+  poolsUrl,
+  type Pool,
+  type PoolsQuery,
+  type PoolsResponse,
+} from "@/lib/api/pools";
+
+/** Return value of {@link usePools}. */
+export interface UsePoolsResult {
+  /** The fetched pools (empty while loading or on error). */
+  pools: Pool[];
+  /** Total number of pools matching the query (for pagination). */
+  total: number;
+  /** The raw response, or `undefined` until the first load resolves. */
+  data: PoolsResponse | undefined;
+  /** True during the initial load when no cached data is available yet. */
+  isLoading: boolean;
+  /** True when the most recent request failed. */
+  isError: boolean;
+  /** The error from the most recent failed request, if any. */
+  error: Error | undefined;
+  /** Manually revalidate (e.g. a "retry" button). */
+  refresh: () => void;
+}
+
+/**
+ * usePools — SWR-cached access to the prediction pool list.
+ *
+ * Prediction-pool metadata is effectively static between updates, so this hook
+ * leans on the cache: identical queries share a single cache entry, concurrent
+ * requests are deduplicated, cached data is served instantly on remount, and
+ * (via the global {@link SWRProvider} config) the data is not revalidated on
+ * window focus or reconnect. Pass a {@link PoolsQuery} to fetch a
+ * filtered/sorted page.
+ *
+ * @example
+ * const { pools, isLoading, isError, refresh } = usePools({ status: "active" });
+ */
+export function usePools(query: PoolsQuery = {}): UsePoolsResult {
+  const { data, error, isLoading, mutate } = useSWR<PoolsResponse>(
+    poolsUrl(query),
+    fetchPools
+  );
+
+  return {
+    pools: data?.pools ?? [],
+    total: data?.total ?? 0,
+    data,
+    isLoading,
+    isError: Boolean(error),
+    error: error as Error | undefined,
+    refresh: () => {
+      void mutate();
+    },
+  };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
                 "recharts": "^3.7.0",
+                "swr": "^2.4.1",
                 "tailwind-merge": "^2.3.0"
             },
             "devDependencies": {
@@ -3413,6 +3414,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/detect-libc": {
@@ -6866,6 +6876,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/swr": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+            "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+            "license": "MIT",
+            "dependencies": {
+                "dequal": "^2.0.3",
+                "use-sync-external-store": "^1.6.0"
+            },
+            "peerDependencies": {
+                "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/tailwind-merge": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "recharts": "^3.7.0",
+        "swr": "^2.4.1",
         "tailwind-merge": "^2.3.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Add an SWR-based caching layer for the dashboard's prediction pool data so that largely-static pool metadata is fetched once, deduplicated, and served from cache on subsequent mounts instead of refetching on every render.

- lib/api/pools.ts: typed client for `GET /api/v1/pools` (Pool / PoolsResponse mirroring the backend schema), a `poolsUrl` cache-key builder, and a `fetchPools` SWR fetcher with explicit non-2xx error handling
- lib/hooks/usePools.ts: `usePools(query)` hook exposing pools/total plus loading, error, and refresh state
- components/providers/SWRProvider.tsx: global SWRConfig tuned for static data (dedupingInterval, no revalidate on focus/reconnect, keepPreviousData, bounded error retries); wired into the root layout
- components/dashboard/PoolsList.tsx: consume the cached data with loading / error (retry) / empty / populated states
- docs: document NEXT_PUBLIC_API_BASE_URL and the caching approach in the frontend README

Existing behavior is preserved (the empty state is shown when no pools are returned). No existing files outside the data layer and PoolsList are changed.

closes https://github.com/Web3Novalabs/predifi/issues/962

