### PR TITLE
feat: reduce re-renders by splitting ToastContext into state and actions contexts

### DIFF
--- a/frontend/app/components-demo/page.tsx
+++ b/frontend/app/components-demo/page.tsx
@@ -9,14 +9,14 @@ import {
   Checkbox,
   Tooltip,
   ToastProvider,
-  useToast,
+  useToastActions,
 } from "@/components/ui";
 
 function ComponentShowcase() {
   const [checkedState, setCheckedState] = useState(false);
   const [indeterminateState, setIndeterminateState] = useState(true);
   const [searchResult, setSearchResult] = useState("");
-  const { addToast } = useToast();
+  const { addToast } = useToastActions();
 
   const handleToastSuccess = () => {
     addToast({

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -4,7 +4,7 @@ export { Skeleton } from "./skeleton";
 export { Input, type InputProps } from "./input";
 export { SearchBar, type SearchBarProps } from "./search-bar";
 export { Toast, toastVariants, type ToastProps } from "./toast";
-export { ToastProvider, useToast } from "./toast-provider";
+export { ToastProvider, useToast, useToastActions } from "./toast-provider";
 export { Checkbox, type CheckboxProps } from "./checkbox";
 export {
   Tooltip,

--- a/frontend/components/ui/toast-provider.tsx
+++ b/frontend/components/ui/toast-provider.tsx
@@ -3,18 +3,50 @@
 import * as React from "react";
 import { Toast, type ToastProps } from "./toast";
 
-type ToastContextType = {
-  toasts: ToastProps[];
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ToastActions = {
   addToast: (toast: Omit<ToastProps, "id" | "onClose">) => void;
   removeToast: (id: string) => void;
 };
 
-const ToastContext = React.createContext<ToastContextType | undefined>(
+// ---------------------------------------------------------------------------
+// Contexts
+//
+// Split into two contexts so components that only call addToast/removeToast
+// are not re-rendered when the toasts[] array changes.
+// ---------------------------------------------------------------------------
+
+/**
+ * ToastStateContext — holds the list of active toasts.
+ * Only the toast renderer (inside ToastProvider) subscribes to this.
+ */
+const ToastStateContext = React.createContext<ToastProps[] | undefined>(
   undefined
 );
 
+/**
+ * ToastActionsContext — holds stable addToast / removeToast callbacks.
+ * These are memoized with useCallback so this context value never changes,
+ * meaning consumers of useToastActions() are never triggered to re-render
+ * by a toast being added or removed.
+ */
+const ToastActionsContext = React.createContext<ToastActions | undefined>(
+  undefined
+);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = React.useState<ToastProps[]>([]);
+
+  const removeToast = React.useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
 
   const addToast = React.useCallback(
     (toast: Omit<ToastProps, "id" | "onClose">) => {
@@ -24,38 +56,80 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     []
   );
 
-  const removeToast = React.useCallback((id: string) => {
-    setToasts((prev) => prev.filter((toast) => toast.id !== id));
-  }, []);
-
-  const contextValue = React.useMemo(
-    () => ({ toasts, addToast, removeToast }),
-    [toasts, addToast, removeToast]
+  // Stable object — only recreated if addToast/removeToast refs change (they won't).
+  const actions = React.useMemo(
+    () => ({ addToast, removeToast }),
+    [addToast, removeToast]
   );
 
   return (
-    <ToastContext.Provider value={contextValue}>
-      {children}
-      <div
-        className="fixed top-4 right-4 z-50 flex flex-col gap-2 w-full max-w-md pointer-events-none"
-        aria-live="polite"
-      >
-        {toasts.map((toast) => (
-          <Toast
-            key={toast.id}
-            {...toast}
-            onClose={() => removeToast(toast.id)}
-          />
-        ))}
-      </div>
-    </ToastContext.Provider>
+    <ToastActionsContext.Provider value={actions}>
+      <ToastStateContext.Provider value={toasts}>
+        {children}
+        <ToastList toasts={toasts} removeToast={removeToast} />
+      </ToastStateContext.Provider>
+    </ToastActionsContext.Provider>
   );
 }
 
-export function useToast() {
-  const context = React.useContext(ToastContext);
+// ---------------------------------------------------------------------------
+// Internal renderer — isolated so only it re-renders when toasts[] changes
+// ---------------------------------------------------------------------------
+
+function ToastList({
+  toasts,
+  removeToast,
+}: {
+  toasts: ToastProps[];
+  removeToast: (id: string) => void;
+}) {
+  return (
+    <div
+      className="fixed top-4 right-4 z-50 flex flex-col gap-2 w-full max-w-md pointer-events-none"
+      aria-live="polite"
+    >
+      {toasts.map((toast) => (
+        <Toast
+          key={toast.id}
+          {...toast}
+          onClose={() => removeToast(toast.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * useToastActions — subscribe only to actions (addToast, removeToast).
+ * This hook does NOT cause re-renders when the toast list changes.
+ * Prefer this in components that trigger toasts but don't render them.
+ */
+export function useToastActions(): ToastActions {
+  const context = React.useContext(ToastActionsContext);
   if (!context) {
-    throw new Error("useToast must be used within a ToastProvider");
+    throw new Error("useToastActions must be used within a ToastProvider");
   }
   return context;
+}
+
+/**
+ * useToast — backward-compatible hook that returns the full context
+ * (toasts state + actions).
+ *
+ * @deprecated Prefer useToastActions() in components that only fire toasts.
+ * Use this only when you need to read the toasts[] list directly.
+ */
+export function useToast() {
+  const toasts = React.useContext(ToastStateContext);
+  const actions = React.useContext(ToastActionsContext);
+
+  if (toasts === undefined || actions === undefined) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+
+  return { toasts, ...actions };
 }


### PR DESCRIPTION
## Summary

Closes #961

Splits the single `ToastContext` into two focused contexts to eliminate unnecessary re-renders.

## Changes

- **`ToastStateContext`** — holds `toasts[]` only. Only the internal `ToastList` renderer subscribes to it.
- **`ToastActionsContext`** — holds stable `addToast`/`removeToast` callbacks (memoized with `useCallback`). This value never changes after mount.
- **`useToastActions()`** — new focused hook for components that fire toasts but don't render them. Zero re-renders from toast state changes.
- **`useToast()`** — kept for backward compatibility, marked `@deprecated`.
- `components-demo` updated to use `useToastActions()`.
- Barrel export updated.

## Before vs After

**Before:** Any component calling `useToast()` re-rendered every time a toast was added or dismissed, because `toasts[]`, `addToast`, and `removeToast` all lived in one context value.

**After:** Components that only trigger toasts subscribe to `ToastActionsContext` (stable, never changes). Only the toast renderer re-renders when `toasts[]` changes.

## Testing

- TypeScript check passes on all modified files
- Existing build errors are pre-existing and unrelated to this PR (NavBar.tsx syntax error, dashboard ssr:false issue)