### PR TITLE
feat(frontend): configure cache-control settings for public static as…

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,30 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        // Build-time hashed assets — safe to cache forever
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        // Public folder assets (images, icons, manifests, fonts)
+        source: "/(:path*\.(?:ico|png|jpg|jpeg|svg|webp|woff|woff2|ttf|otf|json|txt|xml))",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=86400, must-revalidate",
+          },
+        ],
+      },
+    ];
+  },
   // Enable CSS minification and optimization in production
   compress: true,
   // Optimize CSS loading


### PR DESCRIPTION
### Overview
This pull request addresses issue #1238  by configuring optimized Cache-Control HTTP headers for public static assets within the Next.js frontend application. Implementing these headers improves web performance, reduces server load, and enhances the overall user experience by utilizing aggressive browser and CDN caching methods.

### Proposed Changes
Next.js Configuration: Updated the custom header configurations in next.config.js (or next.config.mjs) inside the frontend/ directory.

Immutable Asset Caching: Configured hashed, framework-generated static assets under /_next/static/ with a long-term cache lifetime (public, max-age=31536000, immutable).

Public Directory Assets: Applied an optimized caching strategy for assets served from the public/ directory (such as icons, local fonts, and static images) using a standard revalidation directive (public, max-age=86400, must-revalidate).

### Verification & Testing
The following steps were performed within the frontend/ directory to ensure system stability and quality compliance:

Checked local build compilation.

Verified project formatting and syntax rules by executing pnpm lint.

Validated local server execution via pnpm dev.

Linked Issues
Closes #1238 