### PR TITLE
feat(frontend): FAQ smooth transitions, payout estimator widget & transaction progress tracker

### DIFF
--- a/frontend/app/(marketing)/components/FAQ.tsx
+++ b/frontend/app/(marketing)/components/FAQ.tsx
@@ -71,42 +71,65 @@ const AccordionItem = memo(function AccordionItem({
   isOpen,
   onToggle,
 }: AccordionItemProps) {
-  /**
-   * Stable click handler scoped to this item.
-   * useCallback here is valid — it is called at the top level of the component,
-   * not inside a loop. `onToggle` is stable (parent useCallback), and `index`
-   * is a primitive that never changes for a given list position.
-   */
   const handleClick = useCallback(() => {
     onToggle(index);
   }, [onToggle, index]);
 
   return (
-    <div className="border border-[#FFFFFF1A] rounded-[12px] overflow-hidden transition-all duration-300">
+    <div
+      className={[
+        "rounded-[12px] overflow-hidden",
+        "border transition-[border-color,background-color,box-shadow] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]",
+        isOpen
+          ? "border-[#37B7C3]/60 bg-[#37B7C3]/[0.06] shadow-[0_0_0_1px_rgba(55,183,195,0.15)]"
+          : "border-[#FFFFFF1A] bg-transparent hover:border-[#FFFFFF30] hover:bg-white/[0.03]",
+      ].join(" ")}
+    >
       <button
         onClick={handleClick}
-        className="w-full flex items-center justify-between p-4 text-left focus:outline-none group"
+        aria-expanded={isOpen}
+        className="w-full flex items-center justify-between p-4 md:p-5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[#37B7C3]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent group"
       >
-        <span className="text-sm md:text-[18px] font-medium text-[#FFFFFFCC] group-hover:text-white transition-colors">
+        <span
+          className={[
+            "text-sm md:text-[18px] font-medium transition-colors duration-200",
+            isOpen ? "text-white" : "text-[#FFFFFFCC] group-hover:text-white",
+          ].join(" ")}
+        >
           {question}
         </span>
 
-        {/* Chevron rotates when the item is open */}
-        <ChevronDown
-          className={`w-5 h-5 text-[#FFFFFF80] transition-transform duration-300 ${
-            isOpen ? "rotate-180" : "rotate-0"
-          }`}
-        />
+        {/* Chevron — smooth rotate + color shift */}
+        <span
+          className={[
+            "ml-4 flex-shrink-0 rounded-full p-1",
+            "transition-[transform,background-color,color] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]",
+            isOpen
+              ? "rotate-180 bg-[#37B7C3]/20 text-[#37B7C3]"
+              : "rotate-0 bg-transparent text-[#FFFFFF50]",
+          ].join(" ")}
+        >
+          <ChevronDown className="w-4 h-4" />
+        </span>
       </button>
 
-      {/* Answer — CSS grid trick for smooth height transition */}
+      {/* Answer — CSS grid-rows trick for smooth height + opacity fade */}
       <div
-        className={`grid transition-[grid-template-rows] duration-300 ease-out ${
-          isOpen ? "grid-rows-[1fr] pb-6" : "grid-rows-[0fr]"
-        }`}
+        className={[
+          "grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]",
+          isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        ].join(" ")}
       >
-        <div className="overflow-hidden px-6">
-          <p className="text-[#FFFFFF99] text-sm lg:text-base leading-relaxed">
+        <div className="overflow-hidden">
+          <p
+            className={[
+              "px-5 md:px-6 pb-5 md:pb-6 text-[#FFFFFF99] text-sm lg:text-base leading-relaxed",
+              "transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]",
+              isOpen
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 -translate-y-1",
+            ].join(" ")}
+          >
             {answer}
           </p>
         </div>

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -24,3 +24,9 @@ export {
   CardDescription,
   CardContent,
 } from "./card";
+export { PayoutEstimator, type PayoutEstimatorProps } from "./payout-estimator";
+export {
+  TransactionProgress,
+  type TransactionProgressProps,
+  type TxStatus,
+} from "./transaction-progress";

--- a/frontend/components/ui/payout-estimator.tsx
+++ b/frontend/components/ui/payout-estimator.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState, useCallback, useMemo, useId } from "react";
+import { TrendingUp, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PayoutEstimatorProps {
+  /** Token symbol shown in the UI (default "XLM"). */
+  token?: string;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sanitizeNumeric(raw: string): string {
+  let s = raw.replace(/[^0-9.]/g, "");
+  const dot = s.indexOf(".");
+  if (dot !== -1) {
+    s = s.slice(0, dot + 1) + s.slice(dot + 1).replace(/\./g, "");
+  }
+  // cap to 7 dp (stroop precision)
+  if (dot !== -1) {
+    const [int, frac = ""] = s.split(".");
+    s = `${int}.${frac.slice(0, 7)}`;
+  }
+  // strip leading zeros before decimal
+  s = s.replace(/^0+(\d)/, "$1");
+  return s;
+}
+
+function toNumber(s: string): number {
+  const n = parseFloat(s);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function fmt(n: number, dp = 2): string {
+  return n.toLocaleString("en-US", {
+    minimumFractionDigits: dp,
+    maximumFractionDigits: dp,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function NumericField({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+  suffix,
+  min,
+  max,
+  step,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  suffix?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={id} className="text-xs font-medium text-zinc-400 uppercase tracking-wider">
+        {label}
+      </label>
+      <div className="relative">
+        <input
+          id={id}
+          type="text"
+          inputMode="decimal"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          min={min}
+          max={max}
+          step={step}
+          className={cn(
+            "w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm font-mono text-white placeholder:text-zinc-600",
+            "focus:outline-none focus:ring-2 focus:ring-[#37B7C3]/50 focus:border-[#37B7C3]/60",
+            "transition-[border-color,box-shadow] duration-200",
+            suffix && "pr-14",
+          )}
+        />
+        {suffix && (
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-zinc-500 select-none pointer-events-none">
+            {suffix}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stat row inside the result card
+// ---------------------------------------------------------------------------
+
+function Stat({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div className="flex items-center justify-between py-2 border-b border-white/5 last:border-0">
+      <span className="text-xs text-zinc-400">{label}</span>
+      <span className={cn("text-sm font-mono font-medium", accent ? "text-[#37B7C3]" : "text-white")}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PayoutEstimator
+// ---------------------------------------------------------------------------
+
+export function PayoutEstimator({ token = "XLM", className }: PayoutEstimatorProps) {
+  const uid = useId();
+  const stakeId = `${uid}-stake`;
+  const oddsId = `${uid}-odds`;
+
+  const [stakeRaw, setStakeRaw] = useState("");
+  const [oddsRaw, setOddsRaw] = useState("");
+
+  const handleStake = useCallback((v: string) => setStakeRaw(sanitizeNumeric(v)), []);
+  const handleOdds = useCallback((v: string) => {
+    const s = sanitizeNumeric(v);
+    // cap odds display to 2 dp
+    const dot = s.indexOf(".");
+    if (dot !== -1) {
+      const [int, frac = ""] = s.split(".");
+      setOddsRaw(`${int}.${frac.slice(0, 2)}`);
+    } else {
+      setOddsRaw(s);
+    }
+  }, []);
+
+  const stake = useMemo(() => toNumber(stakeRaw), [stakeRaw]);
+  const odds = useMemo(() => toNumber(oddsRaw), [oddsRaw]);
+
+  const payout = useMemo(() => stake * odds, [stake, odds]);
+  const profit = useMemo(() => payout - stake, [payout, stake]);
+
+  // Visual bar: ratio of profit to payout, capped at 100%
+  const profitRatio = useMemo(() => {
+    if (payout <= 0) return 0;
+    return Math.min((profit / payout) * 100, 100);
+  }, [profit, payout]);
+
+  const hasValues = stake > 0 && odds > 1;
+  const isValidOdds = odds >= 1 || oddsRaw === "";
+
+  return (
+    <div className={cn("rounded-2xl border border-white/10 bg-[#121212] p-5 space-y-5 w-full", className)}>
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <div className="w-8 h-8 rounded-lg bg-[#37B7C3]/15 flex items-center justify-center">
+          <TrendingUp className="w-4 h-4 text-[#37B7C3]" />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-white">Payout Estimator</h3>
+          <p className="text-[10px] text-zinc-500">Estimate your returns before staking</p>
+        </div>
+      </div>
+
+      {/* Inputs */}
+      <div className="grid grid-cols-2 gap-3">
+        <NumericField
+          id={stakeId}
+          label="Stake amount"
+          value={stakeRaw}
+          onChange={handleStake}
+          placeholder="0.00"
+          suffix={token}
+        />
+        <NumericField
+          id={oddsId}
+          label="Odds (multiplier)"
+          value={oddsRaw}
+          onChange={handleOdds}
+          placeholder="1.50"
+          min={1}
+          step={0.01}
+        />
+      </div>
+
+      {!isValidOdds && (
+        <p className="flex items-center gap-1.5 text-xs text-yellow-400">
+          <Info className="w-3 h-3 flex-shrink-0" />
+          Odds must be 1.00 or higher.
+        </p>
+      )}
+
+      {/* Result card */}
+      <div
+        className={cn(
+          "rounded-xl border p-4 space-y-1 transition-[opacity,transform] duration-300 ease-out",
+          hasValues && isValidOdds
+            ? "opacity-100 translate-y-0 border-[#37B7C3]/20 bg-[#37B7C3]/[0.05]"
+            : "opacity-40 translate-y-1 border-white/5 bg-white/[0.02]",
+        )}
+      >
+        <Stat label={`Stake (${token})`} value={hasValues ? fmt(stake) : "—"} />
+        <Stat label="Odds" value={hasValues ? `×${fmt(odds)}` : "—"} />
+        <Stat label={`Estimated profit (${token})`} value={hasValues ? fmt(profit) : "—"} accent={hasValues && profit > 0} />
+        <Stat label={`Total payout (${token})`} value={hasValues ? fmt(payout) : "—"} accent={hasValues} />
+      </div>
+
+      {/* Visual profit bar */}
+      <div className="space-y-1.5">
+        <div className="flex justify-between text-[10px] text-zinc-500">
+          <span>Stake</span>
+          <span>Profit</span>
+        </div>
+        <div className="h-2 w-full rounded-full bg-white/[0.06] overflow-hidden">
+          {/* stake portion */}
+          <div className="h-full flex">
+            <div
+              className="h-full bg-zinc-600 transition-[width] duration-500 ease-out"
+              style={{ width: hasValues ? `${100 - profitRatio}%` : "0%" }}
+            />
+            <div
+              className="h-full bg-[#37B7C3] transition-[width] duration-500 ease-out"
+              style={{ width: hasValues ? `${profitRatio}%` : "0%" }}
+            />
+          </div>
+        </div>
+        <div className="flex justify-between text-[10px]">
+          <span className="text-zinc-500">{hasValues ? `${fmt(100 - profitRatio, 1)}%` : "0%"}</span>
+          <span className={cn("transition-colors", hasValues && profit > 0 ? "text-[#37B7C3]" : "text-zinc-500")}>
+            {hasValues ? `${fmt(profitRatio, 1)}%` : "0%"}
+          </span>
+        </div>
+      </div>
+
+      <p className="text-[10px] text-zinc-600 leading-relaxed">
+        Estimates are illustrative only. Actual payouts depend on final pool odds at resolution.
+      </p>
+    </div>
+  );
+}

--- a/frontend/components/ui/transaction-progress.tsx
+++ b/frontend/components/ui/transaction-progress.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { memo } from "react";
+import { CheckCircle2, Clock, Loader2, XCircle, Send } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TxStatus = "idle" | "submitted" | "processing" | "confirmed" | "failed";
+
+export interface TransactionProgressProps {
+  status: TxStatus;
+  txHash?: string;
+  errorMessage?: string;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Step definitions
+// ---------------------------------------------------------------------------
+
+interface Step {
+  id: "submitted" | "processing" | "confirmed";
+  label: string;
+  sublabel: string;
+}
+
+const STEPS: Step[] = [
+  { id: "submitted", label: "Submitted", sublabel: "Transaction sent to network" },
+  { id: "processing", label: "Processing", sublabel: "Awaiting block confirmation" },
+  { id: "confirmed", label: "Confirmed", sublabel: "Transaction finalised on-chain" },
+];
+
+// ---------------------------------------------------------------------------
+// Order used to decide which steps are "done"
+// ---------------------------------------------------------------------------
+
+const STATUS_ORDER: Record<TxStatus, number> = {
+  idle: -1,
+  submitted: 0,
+  processing: 1,
+  confirmed: 2,
+  failed: 1, // show processing as the point of failure
+};
+
+// ---------------------------------------------------------------------------
+// StepIcon
+// ---------------------------------------------------------------------------
+
+type StepState = "done" | "active" | "failed" | "idle";
+
+const StepIcon = memo(function StepIcon({ state }: { state: StepState }) {
+  const base = "w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 transition-[background-color,border-color,box-shadow] duration-300";
+
+  if (state === "done") {
+    return (
+      <span className={cn(base, "bg-[#37B7C3] shadow-[0_0_10px_rgba(55,183,195,0.4)]")}>
+        <CheckCircle2 className="w-4 h-4 text-[#001112]" />
+      </span>
+    );
+  }
+  if (state === "active") {
+    return (
+      <span className={cn(base, "border-2 border-[#37B7C3] bg-[#37B7C3]/10 shadow-[0_0_10px_rgba(55,183,195,0.3)]")}>
+        <Loader2 className="w-4 h-4 text-[#37B7C3] animate-spin" />
+      </span>
+    );
+  }
+  if (state === "failed") {
+    return (
+      <span className={cn(base, "border-2 border-red-500 bg-red-500/10 shadow-[0_0_10px_rgba(239,68,68,0.3)]")}>
+        <XCircle className="w-4 h-4 text-red-400" />
+      </span>
+    );
+  }
+  // idle
+  return (
+    <span className={cn(base, "border-2 border-white/10 bg-white/[0.03]")}>
+      <span className="w-2 h-2 rounded-full bg-white/20" />
+    </span>
+  );
+});
+
+StepIcon.displayName = "StepIcon";
+
+// ---------------------------------------------------------------------------
+// Connector line between steps
+// ---------------------------------------------------------------------------
+
+const Connector = memo(function Connector({ filled, animated }: { filled: boolean; animated?: boolean }) {
+  return (
+    <div className="flex-1 h-[2px] mx-1 rounded-full bg-white/[0.07] overflow-hidden relative">
+      <div
+        className={cn(
+          "absolute inset-y-0 left-0 rounded-full transition-[width] duration-500 ease-out",
+          filled ? "bg-[#37B7C3] w-full" : "w-0",
+          animated && !filled && "bg-gradient-to-r from-[#37B7C3]/60 to-transparent animate-pulse w-full",
+        )}
+      />
+    </div>
+  );
+});
+
+Connector.displayName = "Connector";
+
+// ---------------------------------------------------------------------------
+// TransactionProgress
+// ---------------------------------------------------------------------------
+
+export const TransactionProgress = memo(function TransactionProgress({
+  status,
+  txHash,
+  errorMessage,
+  className,
+}: TransactionProgressProps) {
+  if (status === "idle") return null;
+
+  const order = STATUS_ORDER[status];
+  const isFailed = status === "failed";
+
+  function stepState(step: Step, stepIdx: number): StepState {
+    const stepOrder = stepIdx;
+    if (isFailed && stepOrder === order) return "failed";
+    if (stepOrder < order) return "done";
+    if (stepOrder === order) return "active";
+    return "idle";
+  }
+
+  // Overall progress percentage (0 → 100)
+  const progressPct = isFailed
+    ? Math.round((order / (STEPS.length - 1)) * 100)
+    : Math.round((order / (STEPS.length - 1)) * 100);
+
+  return (
+    <div className={cn("rounded-2xl border border-white/10 bg-[#121212] p-5 space-y-5 w-full", className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className={cn(
+            "w-8 h-8 rounded-lg flex items-center justify-center transition-colors duration-300",
+            isFailed ? "bg-red-500/15" : "bg-[#37B7C3]/15",
+          )}>
+            <Send className={cn("w-4 h-4", isFailed ? "text-red-400" : "text-[#37B7C3]")} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-white">Transaction Status</h3>
+            <p className="text-[10px] text-zinc-500">Stellar network</p>
+          </div>
+        </div>
+
+        {/* Status badge */}
+        <span className={cn(
+          "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium",
+          status === "confirmed" && "bg-emerald-400/10 text-emerald-400",
+          status === "processing" && "bg-[#37B7C3]/10 text-[#37B7C3]",
+          status === "submitted" && "bg-yellow-400/10 text-yellow-400",
+          status === "failed" && "bg-red-400/10 text-red-400",
+        )}>
+          {status === "confirmed" && <CheckCircle2 className="w-3 h-3" />}
+          {(status === "processing" || status === "submitted") && <Loader2 className="w-3 h-3 animate-spin" />}
+          {status === "failed" && <XCircle className="w-3 h-3" />}
+          {status.charAt(0).toUpperCase() + status.slice(1)}
+        </span>
+      </div>
+
+      {/* Linear progress bar */}
+      <div className="space-y-1">
+        <div className="h-1.5 w-full rounded-full bg-white/[0.06] overflow-hidden">
+          <div
+            className={cn(
+              "h-full rounded-full transition-[width] duration-700 ease-out",
+              isFailed ? "bg-red-500" : "bg-[#37B7C3]",
+            )}
+            style={{ width: `${progressPct}%` }}
+          />
+        </div>
+        <div className="flex justify-between text-[10px] text-zinc-600">
+          <span>0%</span>
+          <span className={cn(isFailed ? "text-red-400" : "text-[#37B7C3]")}>{progressPct}%</span>
+          <span>100%</span>
+        </div>
+      </div>
+
+      {/* Step indicators */}
+      <div className="flex items-center">
+        {STEPS.map((step, idx) => (
+          <div key={step.id} className="flex items-center flex-1 min-w-0">
+            <StepIcon state={stepState(step, idx)} />
+            {idx < STEPS.length - 1 && (
+              <Connector
+                filled={idx < order && !isFailed}
+                animated={idx === order - 1 && status === "processing"}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Step labels */}
+      <div className="flex justify-between">
+        {STEPS.map((step, idx) => {
+          const state = stepState(step, idx);
+          return (
+            <div key={step.id} className="flex flex-col items-center text-center" style={{ width: "33.33%" }}>
+              <span className={cn(
+                "text-xs font-medium transition-colors duration-300",
+                state === "done" && "text-[#37B7C3]",
+                state === "active" && "text-white",
+                state === "failed" && "text-red-400",
+                state === "idle" && "text-zinc-600",
+              )}>
+                {step.label}
+              </span>
+              <span className="text-[10px] text-zinc-600 mt-0.5 leading-tight hidden sm:block">
+                {step.sublabel}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* TX hash */}
+      {txHash && (
+        <div className="rounded-lg bg-white/[0.03] border border-white/5 px-3 py-2 flex items-center justify-between gap-2">
+          <span className="text-[10px] text-zinc-500 flex-shrink-0">TX Hash</span>
+          <span className="text-[10px] font-mono text-zinc-300 truncate">{txHash}</span>
+        </div>
+      )}
+
+      {/* Error message */}
+      {isFailed && errorMessage && (
+        <div className="rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2">
+          <p className="text-xs text-red-400">{errorMessage}</p>
+        </div>
+      )}
+    </div>
+  );
+});
+
+TransactionProgress.displayName = "TransactionProgress";


### PR DESCRIPTION
## Summary

This PR resolves three frontend issues:

- **Closes #1224** — Enhance FAQ accordion with smooth CSS animation transitions
- **Closes #1223** — Add payout estimation tool visual widget
- **Closes #1226** — Implement transaction progress status tracker bar

## Changes

### #1224 — FAQ accordion smooth CSS transitions (`app/(marketing)/components/FAQ.tsx`)
- Container transitions `border-color`, `background-color`, and `box-shadow` on open/close using `cubic-bezier(0.4,0,0.2,1)` for a premium easing feel
- Open item glows with a teal border (`#37B7C3/60`) and a subtle tinted background
- Chevron gains a teal rounded-pill background when active, animates rotation smoothly
- Answer text fades in with `opacity` + `translateY` transition (slides up from -4px)
- Added `aria-expanded` on the trigger button and `focus-visible` ring for keyboard accessibility

### #1223 — Payout Estimator widget (`components/ui/payout-estimator.tsx`)
- Numeric inputs for stake amount and odds multiplier with full sanitization (strips non-numeric chars, single decimal point, 7 dp cap, strips leading zeros)
- Live calculation of estimated profit and total payout
- Animated dual-segment visual bar showing stake vs profit ratio with smooth width transitions
- Result card fades/slides in only when valid values are entered
- Exported from `components/ui/index.ts`

### #1226 — Transaction Progress tracker (`components/ui/transaction-progress.tsx`)
- Three-step tracker: **Submitted → Processing → Confirmed** (or **Failed**)
- Per-step icon states: idle (grey dot) / active (spinning loader, teal ring) / done (teal check) / failed (red X)
- Animated linear progress bar driven by `TxStatus` prop
- Connector lines between steps fill with teal as steps complete
- Step labels and sub-labels below indicators
- Optional TX hash display and error message block for failed state
- Exported from `components/ui/index.ts`

## Test plan

- [ ] `cd frontend && pnpm dev` — verify all pages load
- [ ] Click FAQ items: verify border glow, chevron animation, text fade-in and smooth height expansion
- [ ] Open `PayoutEstimator`, type stake + odds — verify live calculation, profit bar animates, card fades in
- [ ] Render `TransactionProgress` with different `status` values (`submitted`, `processing`, `confirmed`, `failed`) — verify step states, progress bar, error block
- [ ] Run `pnpm lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)