### PR TITLE
fix: add pool tooltips and button loading states

### DIFF
--- a/frontend/components/dashboard/ActivePoolsMetricCard.tsx
+++ b/frontend/components/dashboard/ActivePoolsMetricCard.tsx
@@ -17,6 +17,7 @@ export function ActivePoolsMetricCard() {
       icon={<Box />}
       change={isError ? "Count unavailable" : `${total} live now`}
       changeType={isError ? "neutral" : "positive"}
+      tooltip="Prediction pools that are currently open for participation."
       isLoading={isLoading}
     />
   );

--- a/frontend/components/dashboard/BalanceSection.tsx
+++ b/frontend/components/dashboard/BalanceSection.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { ArrowUpRight } from "lucide-react";
+import { useState } from "react";
 import { Button, Card, CardContent, CardHeader, CardTitle, Skeleton } from "@/components/ui";
 import { formatUsd } from "@/lib/stakeFilters";
 
@@ -8,13 +11,27 @@ interface BalanceSectionProps {
     balance?: number | string | null;
     /** Rewards amount in USD. Defaults to demo value. */
     rewards?: number | string | null;
+    onWithdraw?: () => Promise<void> | void;
+    onClaim?: () => Promise<void> | void;
 }
 
 export function BalanceSection({
     isLoading = false,
     balance = 15255.25,
     rewards = 1255.68,
+    onWithdraw,
+    onClaim,
 }: BalanceSectionProps) {
+    const [pendingAction, setPendingAction] = useState<"withdraw" | "claim" | null>(null);
+
+    const runAction = async (action: "withdraw" | "claim", callback?: () => Promise<void> | void) => {
+        setPendingAction(action);
+        try {
+            await callback?.();
+        } finally {
+            setPendingAction(null);
+        }
+    };
     if (isLoading) {
         return (
             <Card className="bg-[#121212] border-none text-white h-full relative overflow-hidden">
@@ -50,11 +67,11 @@ export function BalanceSection({
                 </div>
 
                 <div className="flex gap-4">
-                    <Button className="bg-primary hover:bg-primary/90 text-black min-w-[140px] rounded-xl h-12 text-base font-medium group">
+                    <Button loading={pendingAction === "withdraw"} onClick={() => runAction("withdraw", onWithdraw)} className="bg-primary hover:bg-primary/90 text-black min-w-[140px] rounded-xl h-12 text-base font-medium group">
                         Withdrawal
                         <ArrowUpRight className="ml-2 w-4 h-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
                     </Button>
-                    <Button className="bg-primary hover:bg-primary text-black border-transparent hover:border-transparent min-w-[140px] rounded-xl h-12 text-base font-medium group bg-[#37B7C3] hover:opacity-90">
+                    <Button loading={pendingAction === "claim"} onClick={() => runAction("claim", onClaim)} className="bg-primary hover:bg-primary text-black border-transparent hover:border-transparent min-w-[140px] rounded-xl h-12 text-base font-medium group bg-[#37B7C3] hover:opacity-90">
                         Claim
                         <ArrowUpRight className="ml-2 w-4 h-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
                     </Button>

--- a/frontend/components/dashboard/MetricCard.tsx
+++ b/frontend/components/dashboard/MetricCard.tsx
@@ -1,6 +1,6 @@
-import { ArrowUpRight, ArrowDownRight, Minus } from "lucide-react";
+import { ArrowUpRight, ArrowDownRight, Info, Minus } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Card, CardContent, Skeleton } from "@/components/ui";
+import { Card, CardContent, Skeleton, Tooltip } from "@/components/ui";
 
 interface MetricCardProps {
     title: string;
@@ -9,6 +9,7 @@ interface MetricCardProps {
     change?: string;
     changeType?: "positive" | "negative" | "neutral";
     subtext?: string;
+    tooltip?: string;
     isLoading?: boolean;
 }
 
@@ -19,6 +20,7 @@ export function MetricCard({
     change,
     changeType = "neutral",
     subtext,
+    tooltip,
     isLoading = false,
 }: MetricCardProps) {
     if (isLoading) {
@@ -44,9 +46,16 @@ export function MetricCard({
                         <div className="text-primary [&>svg]:w-6 [&>svg]:h-6">{icon}</div>
                     </div>
                     <div className="space-y-1">
-                        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                            {title}
-                        </p>
+                        <div className="flex items-center gap-1">
+                            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{title}</p>
+                            {tooltip && (
+                                <Tooltip content={tooltip} side="top">
+                                    <button type="button" aria-label={`About ${title}`} className="text-muted-foreground hover:text-white">
+                                        <Info className="h-3.5 w-3.5" />
+                                    </button>
+                                </Tooltip>
+                            )}
+                        </div>
                         <h3 className="text-3xl font-bold font-mono tracking-tight">{value}</h3>
                         {(change || subtext) && (
                             <div


### PR DESCRIPTION
## Summary

- Add accessible tooltip helper text to the Active Pools dashboard metric.
- Wire Withdraw and Claim buttons to the shared loading spinner state for async network actions.

Closes #1217
Closes #1225
Closes #1214
Closes #697