### PR TITLE
feat(backend): propagate tracing span context in threads

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -18,6 +18,7 @@ pub mod routes;
 pub mod server;
 pub mod session;
 pub mod telemetry;
+pub mod tracing_context;
 pub mod worker;
 pub mod ws;
 

--- a/backend/src/price_cache.rs
+++ b/backend/src/price_cache.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, info};
 
 use crate::response::ApiResponse;
+use crate::tracing_context;
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -100,7 +101,7 @@ const ASSETS: &[(&str, &str)] = &[("BTC", "bitcoin"), ("ETH", "ethereum"), ("XLM
 /// Panics if the reqwest HTTP client cannot be built (this should never
 /// happen in practice).
 pub fn spawn_fetcher(cache: PriceCache) {
-    tokio::spawn(async move {
+    tracing_context::spawn_worker("price_fetcher", async move {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
             .build()

--- a/backend/src/request_logger.rs
+++ b/backend/src/request_logger.rs
@@ -59,7 +59,7 @@ use std::{
 
 use axum::http::{Request, Response};
 use tower::{Layer, Service};
-use tracing::{error, info};
+use tracing::{error, info, info_span, Instrument};
 
 // Layer
 
@@ -132,6 +132,12 @@ where
         // Record when the request arrived so we can measure latency.
         let start = Instant::now();
 
+        let span = info_span!(
+            "http.request",
+            http.method = %method,
+            http.route = %path,
+        );
+
         // Forward the request to the inner service and get back a Future
         // that will eventually produce a Response.
         let inner_future = self.inner.call(req);
@@ -166,6 +172,7 @@ where
             }
 
             result
-        })
+        }
+        .instrument(span))
     }
 }

--- a/backend/src/tracing_context.rs
+++ b/backend/src/tracing_context.rs
@@ -1,0 +1,135 @@
+//! Helpers for propagating [`tracing`] span context across threads and tasks.
+//!
+//! Tokio tasks and OS threads do not automatically inherit the caller's active
+//! span. Use the helpers in this module when spawning background work so logs
+//! and traces remain correlated with the request or parent operation that
+//! triggered them.
+
+use std::future::Future;
+use std::thread::JoinHandle as ThreadJoinHandle;
+
+use tokio::task::JoinHandle as TaskJoinHandle;
+use tracing::Instrument;
+
+/// Spawn a Tokio task that inherits the caller's current span.
+pub fn spawn<F>(future: F) -> TaskJoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    let span = tracing::Span::current();
+    tokio::spawn(future.instrument(span))
+}
+
+/// Spawn a long-lived background worker with a dedicated root span.
+pub fn spawn_worker<F>(worker: &'static str, future: F) -> TaskJoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    let span = tracing::info_span!("worker", worker);
+    tokio::spawn(future.instrument(span))
+}
+
+/// Run blocking work on Tokio's blocking thread pool with the caller's span.
+pub fn spawn_blocking<F, R>(f: F) -> TaskJoinHandle<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || {
+        let _guard = span.enter();
+        f()
+    })
+}
+
+/// Spawn an OS thread that inherits the caller's current span.
+pub fn spawn_thread<F, R>(f: F) -> ThreadJoinHandle<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let span = tracing::Span::current();
+    std::thread::spawn(move || {
+        let _guard = span.enter();
+        f()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::OnceLock;
+    use tracing::Level;
+
+    fn init_test_subscriber() {
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            let _ = tracing_subscriber::fmt()
+                .with_max_level(Level::TRACE)
+                .with_test_writer()
+                .try_init();
+        });
+    }
+
+    #[tokio::test]
+    async fn spawn_preserves_caller_span() {
+        init_test_subscriber();
+
+        let parent = tracing::info_span!("test_parent");
+        let _guard = parent.enter();
+        let parent_id = tracing::Span::current().id();
+
+        let child_id = spawn(async { tracing::Span::current().id() })
+            .await
+            .expect("spawned task should complete");
+
+        assert_eq!(child_id, parent_id);
+    }
+
+    #[tokio::test]
+    async fn spawn_worker_creates_named_span() {
+        init_test_subscriber();
+
+        let worker_id = spawn_worker("test_worker", async {
+            tracing::Span::current()
+                .metadata()
+                .map(|meta| meta.name())
+        })
+        .await
+        .expect("worker task should complete");
+
+        assert_eq!(worker_id, Some("worker"));
+    }
+
+    #[tokio::test]
+    async fn spawn_blocking_preserves_caller_span() {
+        init_test_subscriber();
+
+        let parent = tracing::info_span!("blocking_parent");
+        let _guard = parent.enter();
+        let parent_id = tracing::Span::current().id();
+
+        let child_id = spawn_blocking(|| tracing::Span::current().id())
+            .await
+            .expect("blocking task should complete");
+
+        assert_eq!(child_id, parent_id);
+    }
+
+    #[test]
+    fn spawn_thread_preserves_caller_span() {
+        init_test_subscriber();
+
+        let parent = tracing::info_span!("thread_parent");
+        let _guard = parent.enter();
+        let parent_id = tracing::Span::current().id();
+
+        let child_id = spawn_thread(|| tracing::Span::current().id())
+            .join()
+            .expect("thread should complete");
+
+        assert_eq!(child_id, parent_id);
+    }
+}

--- a/backend/src/worker/stellar_listener.rs
+++ b/backend/src/worker/stellar_listener.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 use tokio::time::interval;
 use tracing::{error, info, warn};
 
+use crate::tracing_context;
+
 const POLL_INTERVAL_SECS: u64 = 5;
 const STATE_KEY: &str = "stellar_listener_latest_ledger";
 
@@ -114,7 +116,7 @@ async fn fetch_events(
 /// `event_bus` – broadcast channel; new predictions are published here
 /// `timeout`   – maximum time to wait for an RPC response
 pub fn spawn(rpc_url: String, db: PgPool, event_bus: crate::ws::EventBus, timeout: Duration) {
-    tokio::spawn(async move {
+    tracing_context::spawn_worker("stellar_listener", async move {
         run(rpc_url, db, event_bus, timeout).await;
     });
 }

--- a/backend/src/ws.rs
+++ b/backend/src/ws.rs
@@ -14,6 +14,8 @@ use axum::{
 };
 use serde::Serialize;
 use tokio::sync::broadcast;
+use tracing::info_span;
+use tracing::Instrument;
 
 const CHANNEL_CAPACITY: usize = 256;
 
@@ -60,7 +62,8 @@ impl EventBus {
 
 /// Axum handler — upgrades the HTTP connection to WebSocket and streams events.
 pub async fn ws_handler(ws: WebSocketUpgrade, State(bus): State<EventBus>) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_socket(socket, bus))
+    let span = info_span!("websocket.connect");
+    ws.on_upgrade(move |socket| handle_socket(socket, bus).instrument(span))
 }
 
 async fn handle_socket(mut socket: WebSocket, bus: EventBus) {


### PR DESCRIPTION
## Summary

- Add `tracing_context` module with `spawn`, `spawn_worker`, `spawn_blocking`, and `spawn_thread` helpers that propagate the active tracing span into spawned work
- Instrument the request logging middleware with an `http.request` span (`http.method`, `http.route`) so handler logs stay correlated with incoming requests
- Update background workers (`price_fetcher`, `stellar_listener`) and the WebSocket upgrade handler to use traced spawns with dedicated worker/connect spans

## Motivation

Tokio tasks and OS threads do not automatically inherit the caller's tracing span. Without explicit propagation, logs from background work are harder to correlate with the request or operation that triggered them. This improves observability for debugging and distributed tracing.

Closes #1192

## Test plan

- [x] `cd backend && cargo test` — 118 passed, 0 failed
- [x] Unit tests for span propagation in `tracing_context` (`spawn`, `spawn_worker`, `spawn_blocking`, `spawn_thread`)
- [ ] Manual: confirm structured logs include span context for HTTP requests and worker tasks in a running server