### PR TITLE
feat(backend): support query parameters in stats api endpoint

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -831,16 +831,33 @@ pub struct ProtocolStats {
 }
 
 /// Fetch protocol-wide aggregate statistics in a single query.
-pub async fn get_protocol_stats(pool: &PgPool) -> Result<ProtocolStats, sqlx::Error> {
+///
+/// When `category` and/or `state` are provided, the aggregates are scoped to
+/// the matching pools (and the bets placed in them). Passing `None` for both
+/// yields the unfiltered protocol-wide totals.
+pub async fn get_protocol_stats(
+    pool: &PgPool,
+    category: Option<&str>,
+    state: Option<&str>,
+) -> Result<ProtocolStats, sqlx::Error> {
     sqlx::query_as::<_, ProtocolStats>(
         r#"
+        WITH filtered_pools AS (
+            SELECT pool_id, total_stake
+            FROM pools
+            WHERE ($1::text IS NULL OR category = $1)
+              AND ($2::text IS NULL OR state = $2)
+        )
         SELECT
-            COALESCE(SUM(total_stake), 0)       AS total_value_locked,
-            (SELECT COUNT(*) FROM predictions)  AS total_bets,
-            COUNT(*)                            AS total_pools
-        FROM pools
+            COALESCE(SUM(total_stake), 0) AS total_value_locked,
+            (SELECT COUNT(*) FROM predictions p
+                WHERE p.pool_id IN (SELECT pool_id FROM filtered_pools)) AS total_bets,
+            COUNT(*) AS total_pools
+        FROM filtered_pools
         "#,
     )
+    .bind(category)
+    .bind(state)
     .fetch_one(pool)
     .await
 }

--- a/backend/src/routes/v1.rs
+++ b/backend/src/routes/v1.rs
@@ -230,16 +230,32 @@ pub async fn get_pool_by_id_handler(
     }
 }
 
+/// Query parameters for the `GET /api/v1/stats` endpoint.
+#[derive(Debug, Deserialize)]
+pub struct StatsQuery {
+    /// Category filter, e.g. "Sports", "Crypto"
+    pub category: Option<String>,
+    /// Pool state filter: "active" | "closed" | "settled"
+    pub status: Option<String>,
+}
+
 /// `GET /api/v1/stats` — protocol-wide aggregate statistics.
 ///
 /// Returns total value locked, total bets placed, and total pools created.
-/// Responds with a database-unavailable error if no pool is configured.
-pub async fn get_stats(State(state): State<AppState>) -> Json<serde_json::Value> {
+/// Optional `category` and `status` query parameters scope the aggregates to
+/// the matching pools. Responds with a database-unavailable error if no pool
+/// is configured.
+pub async fn get_stats(
+    State(state): State<AppState>,
+    Query(params): Query<StatsQuery>,
+) -> Json<serde_json::Value> {
     let Some(db) = &state.db else {
         return Json(json!({ "error": "database not available" }));
     };
 
-    match crate::db::get_protocol_stats(db).await {
+    match crate::db::get_protocol_stats(db, params.category.as_deref(), params.status.as_deref())
+        .await
+    {
         Ok(stats) => Json(json!(stats)),
         Err(e) => Json(json!({ "error": e.to_string() })),
     }


### PR DESCRIPTION
## Summary
`GET /api/v1/stats` now accepts optional `category` and `status` query parameters. When supplied, the aggregate statistics (total value locked, total bets, total pools) are scoped to the matching pools via a `filtered_pools` CTE. Omitting both yields the unfiltered protocol-wide totals as before.

Closes #1181

## Validation
- `cargo build` passes.