### PR TITLE
feat(backend): user referrals reward estimation logic implementation

### DIFF
--- a/backend/src/referrals.rs
+++ b/backend/src/referrals.rs
@@ -97,6 +97,71 @@ pub async fn get_referrals(
     }
 }
 
+/// Basis-point denominator (100% = 10_000 bps).
+const BPS_DENOMINATOR: i128 = 10_000;
+
+/// Estimate the referral reward a referrer would earn on a given volume.
+///
+/// A referrer earns the referral share of the protocol (treasury) fee charged
+/// on the staked volume they brought in:
+///
+/// `reward = volume * (treasury_fee_bps / 10_000) * (referral_fee_bps / 10_000)`
+///
+/// Computed with `i128` intermediates to avoid overflow and floored to whole
+/// token units. Non-positive volumes yield `0`.
+pub fn estimate_referral_reward(
+    referral_volume: i64,
+    treasury_fee_bps: u32,
+    referral_fee_bps: u32,
+) -> i64 {
+    if referral_volume <= 0 {
+        return 0;
+    }
+    let treasury_fee = referral_volume as i128 * treasury_fee_bps as i128 / BPS_DENOMINATOR;
+    let reward = treasury_fee * referral_fee_bps as i128 / BPS_DENOMINATOR;
+    reward.clamp(0, i64::MAX as i128) as i64
+}
+
+/// Response body for `GET /api/v1/referrals/:address/estimate`.
+#[derive(Debug, Serialize)]
+pub struct ReferralRewardEstimate {
+    pub referrer: String,
+    /// Total referred volume (sum of `amount`) for this referrer.
+    pub total_volume: i64,
+    pub treasury_fee_bps: u32,
+    pub referral_fee_bps: u32,
+    /// Estimated reward derived from the referred volume and fee rates.
+    pub estimated_reward: i64,
+}
+
+/// `GET /api/v1/referrals/:address/estimate`
+///
+/// Estimates the referral reward for a referrer based on their total referred
+/// volume and the configured protocol fee rates.
+pub async fn estimate_referral_rewards(
+    address: String,
+    pool: &PgPool,
+    treasury_fee_bps: u32,
+    referral_fee_bps: u32,
+) -> Result<(StatusCode, Json<ApiResponse<ReferralRewardEstimate>>), AppError> {
+    let total_volume = sqlx::query_scalar::<_, i64>(
+        r#"SELECT COALESCE(SUM(amount), 0)::BIGINT FROM referrals WHERE referrer = $1"#,
+    )
+    .bind(&address)
+    .fetch_one(pool)
+    .await?;
+
+    let estimated_reward = estimate_referral_reward(total_volume, treasury_fee_bps, referral_fee_bps);
+
+    Ok(ApiResponse::success(ReferralRewardEstimate {
+        referrer: address,
+        total_volume,
+        treasury_fee_bps,
+        referral_fee_bps,
+        estimated_reward,
+    }))
+}
+
 /// Response body for `GET /api/v1/users/:address/referrals`.
 #[derive(Debug, Serialize)]
 pub struct ReferralEarningsResponse {
@@ -130,5 +195,35 @@ pub async fn get_user_referral_earnings(
             tracing::error!(error = %err, "referral earnings query failed");
             Err(AppError::from(err))
         }
+    }
+}
+
+#[cfg(test)]
+mod estimation_tests {
+    use super::estimate_referral_reward;
+
+    #[test]
+    fn estimates_reward_from_volume_and_fee_rates() {
+        // 1_000_000 volume, 2% treasury fee, 30% referral share => 6_000.
+        assert_eq!(estimate_referral_reward(1_000_000, 200, 3_000), 6_000);
+    }
+
+    #[test]
+    fn non_positive_volume_yields_zero() {
+        assert_eq!(estimate_referral_reward(0, 200, 3_000), 0);
+        assert_eq!(estimate_referral_reward(-100, 200, 3_000), 0);
+    }
+
+    #[test]
+    fn zero_fee_rates_yield_zero() {
+        assert_eq!(estimate_referral_reward(1_000_000, 0, 3_000), 0);
+        assert_eq!(estimate_referral_reward(1_000_000, 200, 0), 0);
+    }
+
+    #[test]
+    fn large_volume_does_not_overflow() {
+        // i64::MAX volume must not panic and must stay within i64 range.
+        let reward = estimate_referral_reward(i64::MAX, 10_000, 10_000);
+        assert_eq!(reward, i64::MAX);
     }
 }

--- a/backend/src/routes/v1.rs
+++ b/backend/src/routes/v1.rs
@@ -523,6 +523,10 @@ pub fn router(
         .route("/prices", get(crate::price_cache::get_prices))
         .route("/referrals/{address}", get(referrals_handler))
         .route(
+            "/referrals/{address}/estimate",
+            get(referral_estimate_handler),
+        )
+        .route(
             "/users/{address}/referrals",
             get(user_referral_earnings_handler),
         )
@@ -556,6 +560,41 @@ async fn referrals_handler(
     match state.db {
         Some(pool) => {
             match crate::referrals::get_referrals(axum::extract::Path(address), State(pool)).await {
+                Ok((status, body)) => (status, body).into_response(),
+                Err(e) => {
+                    ApiResponse::<()>::error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+                        .into_response()
+                }
+            }
+        }
+        None => {
+            ApiResponse::<()>::error(StatusCode::SERVICE_UNAVAILABLE, "database not configured")
+                .into_response()
+        }
+    }
+}
+
+/// `GET /api/v1/referrals/:address/estimate` — estimated referral reward.
+///
+/// Requires a live DB pool; returns 503 if the pool is not configured.
+async fn referral_estimate_handler(
+    axum::extract::Path(address): axum::extract::Path<String>,
+    State(state): State<AppState>,
+) -> axum::response::Response {
+    use crate::response::ApiResponse;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    match state.db {
+        Some(pool) => {
+            match crate::referrals::estimate_referral_rewards(
+                address,
+                &pool,
+                state.config.treasury_fee_bps,
+                state.config.referral_fee_bps,
+            )
+            .await
+            {
                 Ok((status, body)) => (status, body).into_response(),
                 Err(e) => {
                     ApiResponse::<()>::error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string())


### PR DESCRIPTION
## Summary
Adds referral reward estimation logic. A pure `estimate_referral_reward(volume, treasury_fee_bps, referral_fee_bps)` function computes the referral share of the protocol fee on referred volume (using `i128` intermediates to avoid overflow). A new endpoint `GET /api/v1/referrals/:address/estimate` returns the referrer's total referred volume, the configured fee rates, and the estimated reward.

Closes #1180

## Validation
- `cargo build` passes.
- `cargo test estimation_tests` — 4 unit tests pass (basic estimate, non-positive volume, zero fee rates, overflow safety).