### PR TITLE
fix: validate pool invariants in oracle_resolve

### DIFF
--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -4655,6 +4655,8 @@ impl OracleCallback for PredifiContract {
             .get(&pool_key)
             .expect("Pool not found");
 
+        Self::validate_pool_invariants(&pool);
+
         // if pool.state != MarketState::Active {
         //     return Err(PredifiError::InvalidPoolState);
         // }


### PR DESCRIPTION
# PR Description: Invariant Assertion for Outcome Descriptions

## Overview
This PR addresses and resolves the safety bug regarding the outcome descriptions validation in the prediction pools. Specifically, it implements the missing invariant assertion within the multi-oracle resolution pathway. 

During the consensus-driven resolution of a prediction pool, the code must guarantee that the number of human-readable labels provided (`outcome_descriptions`) exactly matches the total number of options available (`options_count`). If this invariant is not strictly checked at the time of resolution, corrupted or outdated storage states (e.g., from outdated migrations or incomplete pool configurations) could propagate downstream. This discrepancy would lead to index out-of-bounds panics when indexing or rendering outcome-related data on client interfaces or indexers.

## Proposed Changes

### Smart Contract (`contract/contracts/predifi-contract/src/lib.rs`)
- Modified the `oracle_resolve` function implementation within the `OracleCallback` implementation block:
  - Added a defensive check to invoke `Self::validate_pool_invariants(&pool);` immediately after retrieving the pool from persistent storage.
  - This check enforces that `pool.outcome_descriptions.len() == pool.options_count` via `assert_eq!`.
  - With this change, both standard operator resolution (`resolve_pool`), price-feed auto-resolution (`resolve_pool_from_price`), and oracle-based resolution (`oracle_resolve`) are now unified under the same strict invariant validation checks.


Closes #1213 
Closes #1215 
Closes #1216
Closes #703 