### PR TITLE
feat(backend): ws wallet filtering, referral stats cache, and user_address/pool_id indexes

### DIFF
--- a/backend/migrations/006_optimize_user_address_indexes.sql
+++ b/backend/migrations/006_optimize_user_address_indexes.sql
@@ -1,0 +1,10 @@
+-- Migration: optimize indexes for user_address columns
+--
+-- Speeds up user-scoped prediction history queries (filter + ORDER BY created_at)
+-- and referral lookups keyed by referred user address.
+
+CREATE INDEX IF NOT EXISTS idx_predictions_user_created
+    ON predictions (user_address, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_referrals_user_address
+    ON referrals (user_address);

--- a/backend/migrations/007_optimize_pool_id_indexes.sql
+++ b/backend/migrations/007_optimize_pool_id_indexes.sql
@@ -1,0 +1,9 @@
+-- Migration: optimize indexes for pool_id columns
+--
+-- Speeds up referral earnings grouped by pool and pool-scoped referral analytics.
+
+CREATE INDEX IF NOT EXISTS idx_referrals_referrer_pool
+    ON referrals (referrer, pool_id);
+
+CREATE INDEX IF NOT EXISTS idx_referrals_pool_id
+    ON referrals (pool_id);

--- a/backend/migrations/008_referrer_stats.sql
+++ b/backend/migrations/008_referrer_stats.sql
@@ -1,0 +1,91 @@
+-- Migration: pre-aggregated referrer statistics for fast volume reads
+--
+-- Maintains incremental aggregates via trigger so referral endpoints avoid
+-- full-table SUM/COUNT(DISTINCT) scans on every request.
+
+CREATE TABLE IF NOT EXISTS referrer_users (
+    referrer      TEXT NOT NULL,
+    user_address  TEXT NOT NULL,
+    PRIMARY KEY (referrer, user_address)
+);
+
+CREATE TABLE IF NOT EXISTS referrer_stats (
+    referrer      TEXT            PRIMARY KEY,
+    total_volume  NUMERIC(32, 7)  NOT NULL DEFAULT 0,
+    unique_users  BIGINT          NOT NULL DEFAULT 0,
+    last_updated  TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS referrer_pool_stats (
+    referrer        TEXT            NOT NULL,
+    pool_id         BIGINT          NOT NULL,
+    total_earned    NUMERIC(32, 7)  NOT NULL DEFAULT 0,
+    referral_count  BIGINT          NOT NULL DEFAULT 0,
+    last_updated    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (referrer, pool_id)
+);
+
+-- Backfill from existing referral rows.
+INSERT INTO referrer_users (referrer, user_address)
+SELECT DISTINCT referrer, user_address FROM referrals
+ON CONFLICT DO NOTHING;
+
+INSERT INTO referrer_stats (referrer, total_volume, unique_users, last_updated)
+SELECT
+    referrer,
+    COALESCE(SUM(amount), 0),
+    COUNT(DISTINCT user_address),
+    NOW()
+FROM referrals
+GROUP BY referrer
+ON CONFLICT (referrer) DO UPDATE SET
+    total_volume = EXCLUDED.total_volume,
+    unique_users = EXCLUDED.unique_users,
+    last_updated = EXCLUDED.last_updated;
+
+INSERT INTO referrer_pool_stats (referrer, pool_id, total_earned, referral_count, last_updated)
+SELECT
+    referrer,
+    pool_id,
+    COALESCE(SUM(amount), 0),
+    COUNT(*),
+    NOW()
+FROM referrals
+GROUP BY referrer, pool_id
+ON CONFLICT (referrer, pool_id) DO UPDATE SET
+    total_earned = EXCLUDED.total_earned,
+    referral_count = EXCLUDED.referral_count,
+    last_updated = EXCLUDED.last_updated;
+
+CREATE OR REPLACE FUNCTION maintain_referrer_stats()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO referrer_users (referrer, user_address)
+    VALUES (NEW.referrer, NEW.user_address)
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO referrer_stats (referrer, total_volume, unique_users, last_updated)
+    VALUES (NEW.referrer, NEW.amount, 1, NOW())
+    ON CONFLICT (referrer) DO UPDATE SET
+        total_volume = referrer_stats.total_volume + NEW.amount,
+        unique_users = (
+            SELECT COUNT(*)::BIGINT FROM referrer_users WHERE referrer = NEW.referrer
+        ),
+        last_updated = NOW();
+
+    INSERT INTO referrer_pool_stats (referrer, pool_id, total_earned, referral_count, last_updated)
+    VALUES (NEW.referrer, NEW.pool_id, NEW.amount, 1, NOW())
+    ON CONFLICT (referrer, pool_id) DO UPDATE SET
+        total_earned = referrer_pool_stats.total_earned + NEW.amount,
+        referral_count = referrer_pool_stats.referral_count + 1,
+        last_updated = NOW();
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_referrals_maintain_stats ON referrals;
+CREATE TRIGGER trg_referrals_maintain_stats
+    AFTER INSERT ON referrals
+    FOR EACH ROW
+    EXECUTE FUNCTION maintain_referrer_stats();

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -827,15 +827,14 @@ pub async fn get_referral_earnings(
     sqlx::query_as::<_, ReferralEarningRow>(
         r#"
         SELECT
-            r.pool_id,
-            pl.name          AS pool_name,
-            COALESCE(SUM(r.amount), 0) AS total_earned,
-            COUNT(r.id)               AS referral_count
-        FROM referrals r
-        JOIN pools pl ON pl.pool_id = r.pool_id
-        WHERE r.referrer = $1
-        GROUP BY r.pool_id, pl.name
-        ORDER BY SUM(r.amount) DESC
+            rps.pool_id,
+            pl.name                    AS pool_name,
+            COALESCE(rps.total_earned, 0)::BIGINT AS total_earned,
+            rps.referral_count
+        FROM referrer_pool_stats rps
+        JOIN pools pl ON pl.pool_id = rps.pool_id
+        WHERE rps.referrer = $1
+        ORDER BY rps.total_earned DESC
         "#,
     )
     .bind(address)

--- a/backend/src/referrals.rs
+++ b/backend/src/referrals.rs
@@ -14,6 +14,9 @@
 //!     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 //! );
 //! CREATE INDEX IF NOT EXISTS idx_referrals_referrer ON referrals (referrer);
+//! CREATE INDEX IF NOT EXISTS idx_referrals_user_address ON referrals (user_address);
+//! CREATE INDEX IF NOT EXISTS idx_referrals_referrer_pool ON referrals (referrer, pool_id);
+//! CREATE INDEX IF NOT EXISTS idx_referrals_pool_id ON referrals (pool_id);
 //! ```
 //!
 //! ## Response
@@ -70,26 +73,30 @@ pub async fn get_referrals(
     let result = sqlx::query_as::<_, Row>(
         r#"
         SELECT
-            COALESCE(SUM(amount), 0)::BIGINT   AS total_volume,
-            COUNT(DISTINCT user_address)::BIGINT AS unique_users
-        FROM referrals
+            COALESCE(total_volume, 0)::BIGINT AS total_volume,
+            unique_users
+        FROM referrer_stats
         WHERE referrer = $1
         "#,
     )
     .bind(&address)
-    .fetch_one(&pool)
+    .fetch_optional(&pool)
     .await;
 
     match result {
-        Ok(row) if row.unique_users == 0 => Ok(ApiResponse::error(
+        Ok(Some(row)) if row.unique_users == 0 => Ok(ApiResponse::error(
             StatusCode::NOT_FOUND,
             format!("no referrals found for {address}"),
         )),
-        Ok(row) => Ok(ApiResponse::success(ReferralStats {
+        Ok(Some(row)) => Ok(ApiResponse::success(ReferralStats {
             referrer: address,
             total_volume: row.total_volume,
             unique_users: row.unique_users,
         })),
+        Ok(None) => Ok(ApiResponse::error(
+            StatusCode::NOT_FOUND,
+            format!("no referrals found for {address}"),
+        )),
         Err(err) => {
             tracing::error!(error = %err, "referrals query failed");
             Err(AppError::from(err))
@@ -145,11 +152,12 @@ pub async fn estimate_referral_rewards(
     referral_fee_bps: u32,
 ) -> Result<(StatusCode, Json<ApiResponse<ReferralRewardEstimate>>), AppError> {
     let total_volume = sqlx::query_scalar::<_, i64>(
-        r#"SELECT COALESCE(SUM(amount), 0)::BIGINT FROM referrals WHERE referrer = $1"#,
+        r#"SELECT COALESCE(total_volume, 0)::BIGINT FROM referrer_stats WHERE referrer = $1"#,
     )
     .bind(&address)
-    .fetch_one(pool)
-    .await?;
+    .fetch_optional(pool)
+    .await?
+    .unwrap_or(0);
 
     let estimated_reward = estimate_referral_reward(total_volume, treasury_fee_bps, referral_fee_bps);
 

--- a/backend/src/ws.rs
+++ b/backend/src/ws.rs
@@ -1,9 +1,9 @@
 //! WebSocket broadcast for live prediction events.
 //!
-//! A single `tokio::sync::broadcast` channel fans out JSON payloads to every
-//! connected client. The indexer calls [`EventBus::send`] whenever a new
-//! prediction is indexed; the WS handler at `GET /ws` forwards each message
-//! to the client until the connection closes.
+//! Clients connect at `GET /api/v1/ws?address=<wallet>` to receive only events
+//! where `user_address` matches the subscribed wallet. Omitting `address` delivers
+//! all events (useful for dashboards). The indexer calls [`EventBus::send`] whenever
+//! a new prediction is indexed.
 
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -13,16 +13,24 @@ use std::sync::{
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
-        State,
+        Query, State,
     },
     response::IntoResponse,
 };
+use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::broadcast;
 use tracing::info_span;
 use tracing::Instrument;
 
 const CHANNEL_CAPACITY: usize = 256;
+
+/// Optional query parameters for the WebSocket endpoint.
+#[derive(Debug, Deserialize, Default)]
+pub struct WsConnectParams {
+    /// When set, only events whose `user_address` equals this value are forwarded.
+    pub address: Option<String>,
+}
 
 /// Shareable handle to the broadcast channel.
 #[derive(Clone)]
@@ -75,43 +83,110 @@ impl EventBus {
     }
 }
 
-/// Axum handler — upgrades the HTTP connection to WebSocket and streams events.
-pub async fn ws_handler(ws: WebSocketUpgrade, State(bus): State<EventBus>) -> impl IntoResponse {
-    let span = info_span!("websocket.connect");
-    ws.on_upgrade(move |socket| handle_socket(socket, bus).instrument(span))
+/// Returns `true` when `json` should be delivered to a subscriber with `wallet_filter`.
+///
+/// When `wallet_filter` is `None`, all well-formed events are delivered.
+/// When set, only events containing a matching `user_address` field are delivered.
+pub fn should_deliver_event(json: &str, wallet_filter: Option<&str>) -> bool {
+    let Some(filter) = wallet_filter else {
+        return true;
+    };
+
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return false;
+    };
+
+    value
+        .get("user_address")
+        .and_then(|v| v.as_str())
+        .is_some_and(|addr| addr == filter)
 }
 
-async fn handle_socket(mut socket: WebSocket, bus: EventBus) {
+/// Axum handler — upgrades the HTTP connection to WebSocket and streams events.
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    Query(params): Query<WsConnectParams>,
+    State(bus): State<EventBus>,
+) -> impl IntoResponse {
+    let wallet_filter = params.address;
+    let span = info_span!("websocket.connect", wallet = ?wallet_filter);
+    ws.on_upgrade(move |socket| handle_socket(socket, bus, wallet_filter).instrument(span))
+}
+
+async fn handle_socket(mut socket: WebSocket, bus: EventBus, wallet_filter: Option<String>) {
     let mut rx = bus.subscribe();
 
     let count = bus.active_connections.fetch_add(1, Ordering::Relaxed) + 1;
-    tracing::info!(active_connections = count, "websocket client connected");
+    tracing::info!(
+        active_connections = count,
+        wallet = ?wallet_filter,
+        "websocket client connected"
+    );
 
-    run_socket(&mut socket, &mut rx).await;
+    run_socket(&mut socket, &mut rx, wallet_filter.as_deref()).await;
 
     let count = bus.active_connections.fetch_sub(1, Ordering::Relaxed) - 1;
     tracing::info!(active_connections = count, "websocket client disconnected");
 }
 
-async fn run_socket(socket: &mut WebSocket, rx: &mut broadcast::Receiver<String>) {
+async fn run_socket(
+    socket: &mut WebSocket,
+    rx: &mut broadcast::Receiver<String>,
+    wallet_filter: Option<&str>,
+) {
     loop {
         tokio::select! {
-            // Forward broadcast messages to the client.
             result = rx.recv() => {
                 match result {
                     Ok(msg) => {
+                        if !should_deliver_event(&msg, wallet_filter) {
+                            continue;
+                        }
                         if socket.send(Message::Text(msg)).await.is_err() {
-                            break; // client disconnected
+                            break;
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(_)) => continue,
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
             }
-            // Stop if the client closes the connection.
             msg = socket.recv() => {
                 if msg.is_none() { break; }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_deliver_event;
+
+    #[test]
+    fn delivers_all_events_when_no_wallet_filter() {
+        let json = r#"{"type":"prediction_placed","user_address":"GABC","pool_id":1}"#;
+        assert!(should_deliver_event(json, None));
+    }
+
+    #[test]
+    fn delivers_event_when_wallet_matches() {
+        let json = r#"{"type":"prediction_placed","user_address":"GABC","pool_id":1}"#;
+        assert!(should_deliver_event(json, Some("GABC")));
+    }
+
+    #[test]
+    fn skips_event_when_wallet_mismatch() {
+        let json = r#"{"type":"prediction_placed","user_address":"GABC","pool_id":1}"#;
+        assert!(!should_deliver_event(json, Some("GXYZ")));
+    }
+
+    #[test]
+    fn skips_malformed_json_when_filter_active() {
+        assert!(!should_deliver_event("not-json", Some("GABC")));
+    }
+
+    #[test]
+    fn skips_event_missing_user_address_when_filter_active() {
+        let json = r#"{"type":"prediction_placed","pool_id":1}"#;
+        assert!(!should_deliver_event(json, Some("GABC")));
     }
 }


### PR DESCRIPTION
PR description
Summary
This PR delivers four backend performance and filtering improvements for the PrediFi Axum server: per-wallet WebSocket event filtering, pre-aggregated referral volume reads, and targeted database indexes on user_address and pool_id columns.

Changes
Task 1 — Filter WebSocket events per subscriber wallet address
Files: backend/src/ws.rs
Added optional ?address=<wallet> query param on GET /api/v1/ws.
Subscribers with an address only receive events whose user_address matches.
Subscribers without address still receive all events (dashboard/admin use case).
Added should_deliver_event() helper with unit tests for match, mismatch, missing field, and malformed JSON.
Usage:

GET /api/v1/ws?address=GABC...
Task 2 — Optimize referrals volume calculations
Files: backend/migrations/008_referrer_stats.sql, backend/src/referrals.rs, backend/src/db.rs
Added referrer_stats, referrer_pool_stats, and referrer_users tables.
Added maintain_referrer_stats() trigger on referrals INSERT to increment aggregates on write.
Backfilled stats from existing referrals rows during migration.
Updated referral read paths to use pre-aggregated tables instead of live SUM() / COUNT(DISTINCT) scans:
GET /api/v1/referrals/:address → referrer_stats
GET /api/v1/referrals/:address/estimate → referrer_stats
GET /api/v1/users/:address/referrals → referrer_pool_stats (via get_referral_earnings)
Impact: Referral endpoints move from O(n) table scans per request to O(1) keyed lookups.

Task 3 — Optimize database indexing for user_address columns
Files: backend/migrations/006_optimize_user_address_indexes.sql
idx_predictions_user_created on predictions (user_address, created_at DESC) — speeds up user prediction history queries that filter by wallet and sort by time.
idx_referrals_user_address on referrals (user_address) — supports user-scoped referral lookups.

Task 4 — Optimize database indexing for pool_id columns
Files: backend/migrations/007_optimize_pool_id_indexes.sql
idx_referrals_referrer_pool on referrals (referrer, pool_id) — speeds up per-pool referral earnings grouped by referrer.
idx_referrals_pool_id on referrals (pool_id) — supports pool-scoped referral analytics.

closes #1152 
closes #1157 
closes #1158 
closes #1159