### PR TITLE
Feat/backend enhancements 1153 1156

### DIFF
--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -10,6 +10,7 @@ pub struct Metrics {
     pub app_info: Gauge,
     pub memory_used_bytes: Gauge,
     pub memory_total_bytes: Gauge,
+    pub active_pools: Gauge,
 }
 
 /// Type alias for a reference-counted [`Metrics`] instance shared across handlers.
@@ -51,11 +52,17 @@ impl Metrics {
             "Total system memory in bytes.",
         ))?;
 
+        let active_pools = Gauge::with_opts(Opts::new(
+            "app_active_pools",
+            "Number of currently active prediction market pools.",
+        ))?;
+
         registry.register(Box::new(http_requests_total.clone()))?;
         registry.register(Box::new(app_up.clone()))?;
         registry.register(Box::new(app_info.clone()))?;
         registry.register(Box::new(memory_used_bytes.clone()))?;
         registry.register(Box::new(memory_total_bytes.clone()))?;
+        registry.register(Box::new(active_pools.clone()))?;
 
         Ok(Self {
             registry,
@@ -64,6 +71,7 @@ impl Metrics {
             app_info,
             memory_used_bytes,
             memory_total_bytes,
+            active_pools,
         })
     }
 
@@ -117,6 +125,10 @@ mod tests {
         assert!(
             names.contains(&"app_memory_total_bytes"),
             "app_memory_total_bytes must be registered"
+        );
+        assert!(
+            names.contains(&"app_active_pools"),
+            "app_active_pools must be registered"
         );
 
         // CounterVec metrics are omitted until a label set is instantiated.
@@ -195,6 +207,15 @@ mod tests {
             !m2_text.contains("GET"),
             "m2 registry must be independent of m1"
         );
+    }
+
+    /// `active_pools` gauge starts at 0 and can be set.
+    #[test]
+    fn metrics_active_pools_gauge_works() {
+        let metrics = Metrics::new().expect("Metrics::new() must succeed");
+        assert_eq!(metrics.active_pools.get(), 0.0, "active_pools must start at 0");
+        metrics.active_pools.set(42.0);
+        assert_eq!(metrics.active_pools.get(), 42.0, "active_pools must reflect set value");
     }
 
     /// `SharedMetrics` (Arc<Metrics>) can be cloned and used from multiple owners.

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -262,6 +262,7 @@ pub struct IndexerOkResponse {
         ReferralEarningDoc,
         ReferralEarningsResponse,
         DependencyStatus,
+        HealthErrors,
         HealthResponse,
         ErrorResponse,
         PoolCreatedPayloadDoc,

--- a/backend/src/redis_cache.rs
+++ b/backend/src/redis_cache.rs
@@ -11,7 +11,7 @@
 //! - JSON serialization for complex types
 //! - Connection pooling via redis ConnectionManager
 
-use redis::{aio::ConnectionManager, AsyncCommands};
+use redis::{aio::ConnectionManager, AsyncCommands, ErrorKind};
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, error, warn};
 
@@ -96,7 +96,11 @@ impl RedisCache {
                 None
             }
             Err(err) => {
-                error!("Redis GET error for {}: {}", key, err);
+                if is_connection_error(err.kind()) {
+                    warn!("Redis connection dropout on GET {}: {}", key, err);
+                } else {
+                    error!("Redis GET error for {}: {}", key, err);
+                }
                 None
             }
         }
@@ -122,7 +126,11 @@ impl RedisCache {
         };
 
         if let Err(err) = conn.set_ex::<_, _, ()>(key, data, ttl_secs).await {
-            error!("Redis SET error for {}: {}", key, err);
+            if is_connection_error(err.kind()) {
+                warn!("Redis connection dropout on SET {}: {}", key, err);
+            } else {
+                error!("Redis SET error for {}: {}", key, err);
+            }
         } else {
             debug!("Cached: {} (TTL: {}s)", key, ttl_secs);
         }
@@ -140,7 +148,11 @@ impl RedisCache {
         let mut conn = manager.clone();
 
         if let Err(err) = conn.del::<_, ()>(key).await {
-            error!("Redis DEL error for {}: {}", key, err);
+            if is_connection_error(err.kind()) {
+                warn!("Redis connection dropout on DEL {}: {}", key, err);
+            } else {
+                error!("Redis DEL error for {}: {}", key, err);
+            }
         } else {
             debug!("Invalidated cache: {}", key);
         }
@@ -161,7 +173,11 @@ impl RedisCache {
         let keys: Vec<String> = match conn.keys(pattern).await {
             Ok(k) => k,
             Err(err) => {
-                error!("Redis KEYS error for pattern {}: {}", pattern, err);
+                if is_connection_error(err.kind()) {
+                    warn!("Redis connection dropout on KEYS {}: {}", pattern, err);
+                } else {
+                    error!("Redis KEYS error for pattern {}: {}", pattern, err);
+                }
                 return;
             }
         };
@@ -172,7 +188,11 @@ impl RedisCache {
 
         // Delete all matching keys
         if let Err(err) = conn.del::<_, ()>(&keys).await {
-            error!("Redis DEL error for pattern {}: {}", pattern, err);
+            if is_connection_error(err.kind()) {
+                warn!("Redis connection dropout on DEL pattern {}: {}", pattern, err);
+            } else {
+                error!("Redis DEL error for pattern {}: {}", pattern, err);
+            }
         } else {
             debug!(
                 "Invalidated {} cache entries matching: {}",
@@ -195,6 +215,15 @@ impl RedisCache {
             .await
             .is_ok()
     }
+}
+
+/// Returns `true` for errors caused by a transient connection dropout.
+///
+/// The `ConnectionManager` automatically reconnects after a dropout, so
+/// these errors are expected during the brief window before reconnection and
+/// should be logged at `warn` rather than `error`.
+fn is_connection_error(kind: ErrorKind) -> bool {
+    matches!(kind, ErrorKind::IoError | ErrorKind::BusyLoadingError)
 }
 
 /// Generate a cache key for a pools list query.

--- a/backend/src/request_logger.rs
+++ b/backend/src/request_logger.rs
@@ -132,6 +132,8 @@ where
         // Record when the request arrived so we can measure latency.
         let start = Instant::now();
 
+        // All per-request context lives on the span so the JSON formatter
+        // emits it once under "span" without duplicating it in "fields".
         let span = info_span!(
             "http.request",
             http.method = %method,
@@ -146,16 +148,16 @@ where
         // future and then run our logging code once it resolves.
         Box::pin(async move {
             let result = inner_future.await;
-            let elapsed_ms = start.elapsed().as_millis();
+            let duration_ms = start.elapsed().as_millis() as u64;
 
             match &result {
                 Ok(response) => {
-                    let status = response.status();
+                    // Emit the status code as a plain integer so JSON
+                    // consumers can filter/aggregate without string parsing.
+                    let status_code = response.status().as_u16();
                     info!(
-                        method = %method,
-                        path = %path,
-                        status = %status,
-                        elapsed_ms = elapsed_ms,
+                        http.status_code = status_code,
+                        http.duration_ms = duration_ms,
                         "request complete"
                     );
                 }
@@ -163,9 +165,7 @@ where
                     // The inner service returned an error before producing a
                     // response (e.g. a panic or an infrastructure failure).
                     error!(
-                        method = %method,
-                        path = %path,
-                        elapsed_ms = elapsed_ms,
+                        http.duration_ms = duration_ms,
                         "request failed"
                     );
                 }

--- a/backend/src/routes/v1.rs
+++ b/backend/src/routes/v1.rs
@@ -291,6 +291,10 @@ pub async fn get_pools(
         crate::db::count_pools_with_filters(db, category, status)
     ) {
         Ok((pools, total)) => {
+            if status == "active" {
+                state.metrics.active_pools.set(total as f64);
+            }
+
             let response = PoolsResponse {
                 pools,
                 total,


### PR DESCRIPTION
Summary
This PR addresses four backend observability and reliability improvements assigned as part of the Stellar Wave Program.

#1153 — metrics.rs: Added app_active_pools Prometheus gauge to Metrics. The gauge is updated in get_pools whenever the status=active filter path reaches the database, giving Prometheus a continuously-refreshed count of live pools without any extra DB queries.

#1154 — request_logger.rs: Refined the JSON log format emitted by the logging middleware. Per-request context (http.method, http.route) now lives exclusively on the tracing span rather than being duplicated as event fields. The response status is emitted as http.status_code (a u16 integer) instead of the Display string "200 OK", and latency is emitted as http.duration_ms — both making the JSON machine-parseable without additional transformation.

#1155 — openapi.rs: Registered the HealthErrors schema in the components(schemas(...)) list. It was defined and derived with ToSchema but omitted from the registration block, which prevented utoipa from resolving the reference inside HealthResponse and broke the Swagger UI rendering of the /health endpoint schema.

#1156 — redis_cache.rs: Added an is_connection_error helper that checks redis::ErrorKind. All four Redis operations (GET, SET, DEL, KEYS) now log at warn! for transient connection dropouts and at error! for unexpected errors. The ConnectionManager already handles automatic reconnection; this change prevents temporary dropout noise from flooding error-level logs and alerting pipelines.

Test plan
 cd backend && cargo test passes (unit tests for metrics, redis_cache, and request_logger cover the changed paths)
 GET /metrics response includes app_active_pools 0 on startup and a non-zero value after at least one GET /api/v1/pools?status=active request
 JSON log lines for HTTP requests contain http.status_code (integer) and http.duration_ms (integer) with no duplicate method/path event fields
 GET /swagger-ui/ renders the /health response schema including the HealthErrors object without a $ref resolution error
 Simulating a Redis dropout (e.g. redis-cli shutdown nosave then restart) produces WARN log lines, not ERROR, during the reconnection window; API calls continue to return data from the DB
Closes #1153
Closes #1154
Closes #1155
Closes #1156