### PR TITLE
feat: cache GET /api/v1/stats endpoint data in Redis

### DIFF
--- a/backend/src/redis_cache.rs
+++ b/backend/src/redis_cache.rs
@@ -24,8 +24,14 @@ pub const POOL_DETAILS_CACHE_TTL: u64 = 30;
 /// Default TTL for user predictions (45 seconds)
 pub const USER_PREDICTIONS_CACHE_TTL: u64 = 45;
 
+/// Default TTL for cached protocol stats (30 seconds)
+pub const STATS_CACHE_TTL: u64 = 30;
+
 /// Redis key pattern matching all cached pool list queries.
 pub const POOLS_CACHE_PATTERN: &str = "pools:*";
+
+/// Redis key pattern matching all cached stats queries.
+pub const STATS_CACHE_PATTERN: &str = "stats:*";
 
 /// Thread-safe Redis cache client with graceful fail-open behaviour.
 ///
@@ -234,6 +240,14 @@ impl RedisCache {
         self.delete_pattern(POOLS_CACHE_PATTERN).await;
     }
 
+    /// Invalidate all cached stats entries.
+    ///
+    /// Call after a pool is created or a prediction is placed so the next
+    /// `GET /api/v1/stats` request reflects the updated aggregates.
+    pub async fn invalidate_stats_cache(&self) {
+        self.delete_pattern(STATS_CACHE_PATTERN).await;
+    }
+
     /// Check if a cache entry exists without deserializing it
     ///
     /// Useful for cache-aside pattern to determine if we need to populate the cache
@@ -310,6 +324,16 @@ pub fn pool_details_cache_key(pool_id: i64) -> String {
 /// Generate a cache key for a user's paginated predictions list.
 pub fn user_predictions_cache_key(address: &str, limit: i64, offset: i64) -> String {
     format!("user:{}:predictions:{}:{}", address, limit, offset)
+}
+
+/// Generate a cache key for the protocol stats endpoint.
+///
+/// The key encodes the optional `category` and `status` filter parameters so
+/// that different filter combinations are cached independently.
+pub fn stats_cache_key(category: Option<&str>, status: Option<&str>) -> String {
+    let cat = category.unwrap_or("all");
+    let st = status.unwrap_or("all");
+    format!("stats:{}:{}", cat, st)
 }
 
 #[cfg(test)]
@@ -409,5 +433,46 @@ mod tests {
 
         // Verify pattern constant
         assert_eq!(POOLS_CACHE_PATTERN, "pools:*");
+    }
+
+    #[test]
+    fn test_stats_cache_key_generation() {
+        assert_eq!(stats_cache_key(None, None), "stats:all:all");
+        assert_eq!(stats_cache_key(Some("sports"), None), "stats:sports:all");
+        assert_eq!(stats_cache_key(None, Some("active")), "stats:all:active");
+        assert_eq!(
+            stats_cache_key(Some("crypto"), Some("closed")),
+            "stats:crypto:closed"
+        );
+    }
+
+    #[test]
+    fn test_stats_cache_key_uniqueness() {
+        let key_all = stats_cache_key(None, None);
+        let key_cat = stats_cache_key(Some("sports"), None);
+        let key_st = stats_cache_key(None, Some("active"));
+        let key_both = stats_cache_key(Some("sports"), Some("active"));
+
+        assert_ne!(key_all, key_cat);
+        assert_ne!(key_all, key_st);
+        assert_ne!(key_all, key_both);
+        assert_ne!(key_cat, key_both);
+    }
+
+    #[test]
+    fn test_stats_cache_pattern_constant() {
+        assert_eq!(STATS_CACHE_PATTERN, "stats:*");
+    }
+
+    #[tokio::test]
+    async fn test_stats_cache_invalidation() {
+        let cache = RedisCache::disabled();
+        // Should not panic; no-ops on a disabled cache
+        cache.invalidate_stats_cache().await;
+    }
+
+    #[test]
+    fn test_stats_cache_ttl() {
+        assert_eq!(STATS_CACHE_TTL, 30);
     }
 }

--- a/backend/src/routes/v1.rs
+++ b/backend/src/routes/v1.rs
@@ -257,10 +257,11 @@ pub struct StatsQuery {
 
 /// `GET /api/v1/stats` — protocol-wide aggregate statistics.
 ///
-/// Returns total value locked, total bets placed, and total pools created.
-/// Optional `category` and `status` query parameters scope the aggregates to
-/// the matching pools. Responds with a database-unavailable error if no pool
-/// is configured.
+/// Implements the **cache-aside pattern**:
+/// 1. Check Redis for a cached result keyed by `category` and `status`.
+/// 2. On cache hit: return the cached value.
+/// 3. On cache miss: fetch from the database and cache for
+///    [`STATS_CACHE_TTL`](crate::redis_cache::STATS_CACHE_TTL) seconds.
 pub async fn get_stats(
     State(state): State<AppState>,
     Query(params): Query<StatsQuery>,
@@ -276,10 +277,26 @@ pub async fn get_stats(
         ).into_response();
     };
 
+    let cache_key = crate::redis_cache::stats_cache_key(
+        params.category.as_deref(),
+        params.status.as_deref(),
+    );
+
+    if let Some(cached) = state.redis.get::<serde_json::Value>(&cache_key).await {
+        return (StatusCode::OK, Json(cached)).into_response();
+    }
+
     match crate::db::get_protocol_stats(db, params.category.as_deref(), params.status.as_deref())
         .await
     {
-        Ok(stats) => ApiResponse::success(stats).into_response(),
+        Ok(stats) => {
+            let json_response = serde_json::json!(&stats);
+            state
+                .redis
+                .set(&cache_key, &json_response, crate::redis_cache::STATS_CACHE_TTL)
+                .await;
+            ApiResponse::success(stats).into_response()
+        }
         Err(e) => ApiResponse::<()>::error(
             StatusCode::INTERNAL_SERVER_ERROR,
             error_codes::INTERNAL_ERROR,
@@ -582,6 +599,7 @@ pub async fn ingest_pool_created(
     match crate::db::insert_pool_from_event(db, &event).await {
         Ok(()) => {
             state.redis.invalidate_pools_cache().await;
+            state.redis.invalidate_stats_cache().await;
             let response = json!({ "status": "ok", "pool_id": event.pool_id });
             ApiResponse::success(response).into_response()
         }
@@ -634,6 +652,7 @@ pub async fn ingest_prediction_placed(
                 "outcome": event.outcome,
                 "amount": event.amount,
             }));
+            state.redis.invalidate_stats_cache().await;
             let response = json!({ "status": "ok", "pool_id": event.pool_id });
             ApiResponse::success(response).into_response()
         }
@@ -923,5 +942,57 @@ mod cache_aside_tests {
         assert_eq!(sort_new, "pools:new:all:active:20:0");
         assert_eq!(sort_popular, "pools:popular:all:active:20:0");
         assert_eq!(sort_ending, "pools:ending_soon:all:active:20:0");
+    }
+
+    /// Test stats cache-aside pattern: miss, populate, verify no-op on disabled cache.
+    #[tokio::test]
+    async fn test_stats_cache_aside_pattern() {
+        use crate::redis_cache::{stats_cache_key, RedisCache, STATS_CACHE_TTL};
+
+        let cache = RedisCache::disabled();
+        let key = stats_cache_key(None, None);
+
+        // Cache miss
+        let cached: Option<serde_json::Value> = cache.get(&key).await;
+        assert!(cached.is_none());
+
+        // Populate (no-ops on disabled cache)
+        let data = serde_json::json!({
+            "total_value_locked": 1000,
+            "total_bets": 50,
+            "total_pools": 10
+        });
+        cache.set(&key, &data, STATS_CACHE_TTL).await;
+
+        // Still None — disabled cache always returns None
+        let cached: Option<serde_json::Value> = cache.get(&key).await;
+        assert!(cached.is_none());
+    }
+
+    /// Test that stats cache keys are unique per filter combination.
+    #[test]
+    fn test_stats_cache_key_uniqueness() {
+        use crate::redis_cache::stats_cache_key;
+
+        let k1 = stats_cache_key(None, None);
+        let k2 = stats_cache_key(Some("sports"), None);
+        let k3 = stats_cache_key(None, Some("active"));
+        let k4 = stats_cache_key(Some("crypto"), Some("closed"));
+
+        assert_ne!(k1, k2);
+        assert_ne!(k1, k3);
+        assert_ne!(k1, k4);
+        assert_ne!(k2, k3);
+        assert_ne!(k2, k4);
+    }
+
+    /// Test stats cache invalidation no-ops on a disabled cache.
+    #[tokio::test]
+    async fn test_stats_cache_invalidation_on_new_data() {
+        use crate::redis_cache::RedisCache;
+
+        let cache = RedisCache::disabled();
+        // Should not panic
+        cache.invalidate_stats_cache().await;
     }
 }


### PR DESCRIPTION
 
  feat: cache GET /api/v1/stats endpoint data in Redis
  
  Summary
  
  Implements the cache-aside pattern for the GET /api/v1/stats endpoint to reduce repeated
  database aggregation queries.
  
  Changes
  
  backend/src/redis_cache.rs
  
  - Added STATS_CACHE_TTL = 30 (30-second TTL)
  - Added STATS_CACHE_PATTERN = "stats:*" for bulk invalidation
  - Added stats_cache_key(category, status) — encodes filter params into a Redis key (e.g.
  stats:sports:active, stats:all:all)
  - Added invalidate_stats_cache() method
  - Added unit tests for key generation, uniqueness, TTL, and invalidation
  
  backend/src/routes/v1.rs
  
  - get_stats: check Redis first → on hit return cached value; on miss query DB, cache result for
  30s, return
  - ingest_pool_created: invalidates stats cache on new pool (affects total_pools /
  total_value_locked)
  - ingest_prediction_placed: invalidates stats cache on new bet (affects total_bets /
  total_value_locked)
  - Added unit tests for the cache-aside flow
  
  Behaviour
  
  - Stats are served from Redis for up to 30 seconds after the last write event
  - Cache is invalidated immediately when a pool is created or a prediction is placed, so stale
  data is bounded
  - Falls back gracefully to the database when Redis is unavailable (fail-open)
  closes #1145