### PR TITLE
feat: harden workers/sessions, wallet errors, and contract CI/CD

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -1,0 +1,213 @@
+name: Contract CI/CD
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - "contract/**"
+      - ".github/workflows/contract-ci.yml"
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "contract/**"
+      - ".github/workflows/contract-ci.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: contract-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  WASM_SIZE_THRESHOLD_KB: 200
+
+jobs:
+  check:
+    name: cargo check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: ./contract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contract/target
+          key: ${{ runner.os }}-contract-${{ hashFiles('contract/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-contract-
+      - name: cargo check
+        run: cargo check --workspace --target wasm32-unknown-unknown
+
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: ./contract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: ./contract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: wasm32-unknown-unknown
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contract/target
+          key: ${{ runner.os }}-contract-clippy-${{ hashFiles('contract/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-contract-clippy-
+      - name: cargo clippy
+        run: cargo clippy --workspace --target wasm32-unknown-unknown -- -D warnings
+
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: ./contract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contract/target
+          key: ${{ runner.os }}-contract-test-${{ hashFiles('contract/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-contract-test-
+      - name: cargo test
+        run: cargo test --workspace
+
+  wasm-build:
+    name: WASM build verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: ./contract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-opt (binaryen)
+        run: |
+          BINARYEN_VERSION="120"
+          curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz" \
+            | tar -xz -C /tmp
+          sudo mv "/tmp/binaryen-version_${BINARYEN_VERSION}/bin/wasm-opt" /usr/local/bin/wasm-opt
+          wasm-opt --version
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contract/target
+          key: ${{ runner.os }}-contract-wasm-${{ hashFiles('contract/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-contract-wasm-
+      - name: Build release WASM
+        run: cargo build --workspace --target wasm32-unknown-unknown --release
+      - name: Optimize and verify WASM
+        run: |
+          WASM_DIR="target/wasm32-unknown-unknown/release"
+          for CONTRACT in predifi_contract access_control; do
+            RAW="${WASM_DIR}/${CONTRACT}.wasm"
+            [[ -f "$RAW" ]] || continue
+            OPT="${WASM_DIR}/${CONTRACT}-optimized.wasm"
+            wasm-opt -O3 --strip-debug --enable-bulk-memory --enable-sign-ext -o "$OPT" "$RAW"
+            BYTES=$(wc -c < "$OPT")
+            KB=$(( BYTES / 1024 ))
+            echo "${CONTRACT}: ${KB} KB (${BYTES} bytes)"
+            if [[ "$KB" -gt "$WASM_SIZE_THRESHOLD_KB" ]]; then
+              echo "::error::${CONTRACT} WASM exceeds ${WASM_SIZE_THRESHOLD_KB} KB threshold"
+              exit 1
+            fi
+          done
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-wasm-${{ github.sha }}
+          path: |
+            contract/target/wasm32-unknown-unknown/release/predifi_contract.wasm
+            contract/target/wasm32-unknown-unknown/release/predifi_contract-optimized.wasm
+            contract/target/wasm32-unknown-unknown/release/access_control.wasm
+            contract/target/wasm32-unknown-unknown/release/access_control-optimized.wasm
+          if-no-files-found: warn
+          retention-days: 14
+
+  deploy-testnet:
+    name: Deploy to testnet
+    needs: [check, fmt, clippy, test, wasm-build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ./contract
+    environment: testnet
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli --features opt
+      - name: Install wasm-opt
+        run: |
+          BINARYEN_VERSION="120"
+          curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz" \
+            | tar -xz -C /tmp
+          sudo mv "/tmp/binaryen-version_${BINARYEN_VERSION}/bin/wasm-opt" /usr/local/bin/wasm-opt
+      - name: Configure testnet identity
+        env:
+          STELLAR_SECRET_KEY: ${{ secrets.STELLAR_TESTNET_SECRET_KEY }}
+        run: |
+          if [[ -z "${STELLAR_SECRET_KEY}" ]]; then
+            echo "::error::STELLAR_TESTNET_SECRET_KEY secret is not set"
+            exit 1
+          fi
+          printf '%s\n' "${STELLAR_SECRET_KEY}" | stellar keys add ci-deploy --secret-key
+          stellar network add testnet \
+            --rpc-url https://soroban-testnet.stellar.org:443 \
+            --network-passphrase "Test SDF Network ; September 2015" || true
+      - name: Build and deploy
+        run: |
+          chmod +x scripts/deploy.sh
+          ./scripts/deploy.sh testnet ci-deploy
+        env:
+          STELLAR_NETWORK: testnet

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -1,30 +1,471 @@
-//! HTTP extractor for authenticated user sessions.
+//! Hardened session management for authenticated users.
 //!
-//! This module provides a small Axum extractor that reads the `Authorization`
-//! header (expecting a `Bearer <token>` value) and exposes a typed
-//! `UserSession` for route handlers. The extractor intentionally performs only
-//! minimal parsing and does not validate tokens — callers may extend it to
-//! verify signatures or look up session state in Redis/DB as needed.
+//! Features:
+//! - Session fixation prevention (rotate session id on authenticate)
+//! - Idle timeout enforcement
+//! - Concurrent session limits per user
+//! - Session invalidation on password/key changes
+//! - Session activity logging for audit trails
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use axum::async_trait;
 use axum::extract::FromRequestParts;
 use axum::http::{request::Parts, StatusCode};
 use http::header::AUTHORIZATION;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-/// Represents an authenticated user session extracted from the request.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+/// Default idle timeout (30 minutes).
+pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 30 * 60;
+/// Default maximum concurrent sessions per user.
+pub const DEFAULT_MAX_SESSIONS_PER_USER: usize = 5;
+/// Cap on retained activity log entries.
+const ACTIVITY_LOG_CAPACITY: usize = 2_000;
+
+/// Configuration for the session store.
+#[derive(Debug, Clone, Copy)]
+pub struct SessionConfig {
+    pub idle_timeout: Duration,
+    pub max_sessions_per_user: usize,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            idle_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
+            max_sessions_per_user: DEFAULT_MAX_SESSIONS_PER_USER,
+        }
+    }
+}
+
+/// Represents an authenticated user session.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct UserSession {
-    /// The principal identifier extracted from the Authorization token.
-    /// For PrediFi this is commonly the user's wallet address (e.g. `G...`).
+    /// Opaque session identifier (rotated on login to prevent fixation).
+    pub session_id: String,
+    /// The principal identifier (wallet address, e.g. `G...`).
     pub user_address: String,
 }
 
-/// Simple extractor that expects `Authorization: Bearer <token>`.
+/// Internal stored session state.
+#[derive(Debug, Clone)]
+struct StoredSession {
+    session_id: String,
+    user_address: String,
+    /// Credential/key version at creation time; bumping invalidates sessions.
+    key_version: u64,
+    created_at: Instant,
+    last_activity: Instant,
+}
+
+/// Audit event kinds for session activity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionActivityKind {
+    Created,
+    Authenticated,
+    Renewed,
+    IdleTimeout,
+    ConcurrentLimitEvicted,
+    InvalidatedKeyChange,
+    Logout,
+    RejectedFixation,
+    RejectedMissing,
+    RejectedExpired,
+}
+
+/// Single activity log entry.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionActivity {
+    pub kind: SessionActivityKind,
+    pub user_address: String,
+    pub session_id: Option<String>,
+    pub detail: String,
+    pub at_unix_ms: u64,
+}
+
+/// In-memory session store with hardening controls.
+#[derive(Clone)]
+pub struct SessionStore {
+    inner: Arc<SessionStoreInner>,
+}
+
+struct SessionStoreInner {
+    config: SessionConfig,
+    /// session_id → session
+    sessions: Mutex<HashMap<String, StoredSession>>,
+    /// user_address → ordered session ids (oldest first)
+    by_user: Mutex<HashMap<String, VecDeque<String>>>,
+    /// user_address → credential/key version
+    key_versions: Mutex<HashMap<String, u64>>,
+    activity: Mutex<VecDeque<SessionActivity>>,
+}
+
+impl Default for SessionStore {
+    fn default() -> Self {
+        Self::new(SessionConfig::default())
+    }
+}
+
+impl SessionStore {
+    pub fn new(config: SessionConfig) -> Self {
+        Self {
+            inner: Arc::new(SessionStoreInner {
+                config,
+                sessions: Mutex::new(HashMap::new()),
+                by_user: Mutex::new(HashMap::new()),
+                key_versions: Mutex::new(HashMap::new()),
+                activity: Mutex::new(VecDeque::new()),
+            }),
+        }
+    }
+
+    /// Create a new session, rotating the session id (fixation prevention).
+    ///
+    /// If `previous_session_id` is provided (e.g. pre-auth cookie), it is
+    /// destroyed and a fresh id is issued — never reuse the pre-login id.
+    pub fn create_session(
+        &self,
+        user_address: &str,
+        previous_session_id: Option<&str>,
+    ) -> UserSession {
+        if let Some(old) = previous_session_id {
+            if self.destroy_session(old) {
+                self.log(
+                    SessionActivityKind::RejectedFixation,
+                    user_address,
+                    Some(old),
+                    "pre-auth session id discarded; new id issued",
+                );
+            }
+        }
+
+        let session_id = generate_session_id();
+        let key_version = self.current_key_version(user_address);
+        let now = Instant::now();
+
+        {
+            let mut sessions = self.inner.sessions.lock().expect("sessions");
+            let mut by_user = self.inner.by_user.lock().expect("by_user");
+
+            let user_sessions = by_user
+                .entry(user_address.to_string())
+                .or_insert_with(VecDeque::new);
+
+            // Enforce concurrent session limit (evict oldest).
+            while user_sessions.len() >= self.inner.config.max_sessions_per_user {
+                if let Some(evicted_id) = user_sessions.pop_front() {
+                    sessions.remove(&evicted_id);
+                    self.log(
+                        SessionActivityKind::ConcurrentLimitEvicted,
+                        user_address,
+                        Some(&evicted_id),
+                        "evicted oldest session due to concurrent limit",
+                    );
+                }
+            }
+
+            sessions.insert(
+                session_id.clone(),
+                StoredSession {
+                    session_id: session_id.clone(),
+                    user_address: user_address.to_string(),
+                    key_version,
+                    created_at: now,
+                    last_activity: now,
+                },
+            );
+            user_sessions.push_back(session_id.clone());
+        }
+
+        self.log(
+            SessionActivityKind::Created,
+            user_address,
+            Some(&session_id),
+            "session created",
+        );
+        self.log(
+            SessionActivityKind::Authenticated,
+            user_address,
+            Some(&session_id),
+            "user authenticated",
+        );
+
+        UserSession {
+            session_id,
+            user_address: user_address.to_string(),
+        }
+    }
+
+    /// Validate a session token and refresh idle timer. Returns `None` if invalid/expired.
+    pub fn validate_and_touch(&self, session_id: &str) -> Option<UserSession> {
+        let mut sessions = self.inner.sessions.lock().expect("sessions");
+        let session = match sessions.get_mut(session_id) {
+            Some(s) => s,
+            None => {
+                self.log(
+                    SessionActivityKind::RejectedMissing,
+                    "",
+                    Some(session_id),
+                    "unknown session id",
+                );
+                return None;
+            }
+        };
+
+        let idle = session.last_activity.elapsed();
+        if idle > self.inner.config.idle_timeout {
+            let user = session.user_address.clone();
+            let sid = session.session_id.clone();
+            drop(sessions);
+            self.destroy_session(&sid);
+            self.log(
+                SessionActivityKind::IdleTimeout,
+                &user,
+                Some(&sid),
+                &format!("idle for {}s", idle.as_secs()),
+            );
+            self.log(
+                SessionActivityKind::RejectedExpired,
+                &user,
+                Some(&sid),
+                "session expired due to idle timeout",
+            );
+            return None;
+        }
+
+        let current_kv = self.current_key_version(&session.user_address);
+        if session.key_version != current_kv {
+            let user = session.user_address.clone();
+            let sid = session.session_id.clone();
+            drop(sessions);
+            self.destroy_session(&sid);
+            self.log(
+                SessionActivityKind::InvalidatedKeyChange,
+                &user,
+                Some(&sid),
+                "session key_version mismatch",
+            );
+            return None;
+        }
+
+        session.last_activity = Instant::now();
+        let out = UserSession {
+            session_id: session.session_id.clone(),
+            user_address: session.user_address.clone(),
+        };
+        self.log(
+            SessionActivityKind::Renewed,
+            &out.user_address,
+            Some(&out.session_id),
+            "activity renewed",
+        );
+        Some(out)
+    }
+
+    /// Invalidate all sessions for a user after a password/key change.
+    pub fn invalidate_on_key_change(&self, user_address: &str) {
+        {
+            let mut versions = self.inner.key_versions.lock().expect("key_versions");
+            let entry = versions.entry(user_address.to_string()).or_insert(0);
+            *entry = entry.saturating_add(1);
+        }
+
+        let ids: Vec<String> = {
+            let by_user = self.inner.by_user.lock().expect("by_user");
+            by_user
+                .get(user_address)
+                .map(|q| q.iter().cloned().collect())
+                .unwrap_or_default()
+        };
+
+        for id in &ids {
+            self.destroy_session(id);
+            self.log(
+                SessionActivityKind::InvalidatedKeyChange,
+                user_address,
+                Some(id),
+                "invalidated after password/key change",
+            );
+        }
+    }
+
+    /// Explicit logout — destroy a single session.
+    pub fn logout(&self, session_id: &str) -> bool {
+        if let Some(user) = self
+            .inner
+            .sessions
+            .lock()
+            .expect("sessions")
+            .get(session_id)
+            .map(|s| s.user_address.clone())
+        {
+            let ok = self.destroy_session(session_id);
+            if ok {
+                self.log(
+                    SessionActivityKind::Logout,
+                    &user,
+                    Some(session_id),
+                    "user logged out",
+                );
+            }
+            return ok;
+        }
+        false
+    }
+
+    /// Count active sessions for a user (after purging idle ones).
+    pub fn active_session_count(&self, user_address: &str) -> usize {
+        self.purge_idle_for_user(user_address);
+        self.inner
+            .by_user
+            .lock()
+            .expect("by_user")
+            .get(user_address)
+            .map(|q| q.len())
+            .unwrap_or(0)
+    }
+
+    /// Recent activity log (newest last).
+    pub fn activity_log(&self) -> Vec<SessionActivity> {
+        self.inner
+            .activity
+            .lock()
+            .expect("activity")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    fn current_key_version(&self, user_address: &str) -> u64 {
+        *self
+            .inner
+            .key_versions
+            .lock()
+            .expect("key_versions")
+            .get(user_address)
+            .unwrap_or(&0)
+    }
+
+    fn destroy_session(&self, session_id: &str) -> bool {
+        let removed = {
+            let mut sessions = self.inner.sessions.lock().expect("sessions");
+            sessions.remove(session_id)
+        };
+        if let Some(session) = removed {
+            let mut by_user = self.inner.by_user.lock().expect("by_user");
+            if let Some(q) = by_user.get_mut(&session.user_address) {
+                q.retain(|id| id != session_id);
+                if q.is_empty() {
+                    by_user.remove(&session.user_address);
+                }
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    fn purge_idle_for_user(&self, user_address: &str) {
+        let timeout = self.inner.config.idle_timeout;
+        let stale: Vec<String> = {
+            let sessions = self.inner.sessions.lock().expect("sessions");
+            let by_user = self.inner.by_user.lock().expect("by_user");
+            by_user
+                .get(user_address)
+                .map(|q| {
+                    q.iter()
+                        .filter(|id| {
+                            sessions
+                                .get(*id)
+                                .map(|s| s.last_activity.elapsed() > timeout)
+                                .unwrap_or(true)
+                        })
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        for id in stale {
+            self.destroy_session(&id);
+            self.log(
+                SessionActivityKind::IdleTimeout,
+                user_address,
+                Some(&id),
+                "purged idle session",
+            );
+        }
+    }
+
+    fn log(
+        &self,
+        kind: SessionActivityKind,
+        user_address: &str,
+        session_id: Option<&str>,
+        detail: &str,
+    ) {
+        let entry = SessionActivity {
+            kind,
+            user_address: user_address.to_string(),
+            session_id: session_id.map(|s| s.to_string()),
+            detail: detail.to_string(),
+            at_unix_ms: unix_ms_now(),
+        };
+        tracing::info!(
+            kind = ?entry.kind,
+            user = %entry.user_address,
+            session_id = ?entry.session_id,
+            detail = %entry.detail,
+            "session.activity"
+        );
+        let mut log = self.inner.activity.lock().expect("activity");
+        if log.len() >= ACTIVITY_LOG_CAPACITY {
+            log.pop_front();
+        }
+        log.push_back(entry);
+    }
+}
+
+fn generate_session_id() -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    Instant::now().hash(&mut hasher);
+    unix_ms_now().hash(&mut hasher);
+    fastrand_u64().hash(&mut hasher);
+    format!("sess_{:016x}{:016x}", hasher.finish(), fastrand_u64())
+}
+
+fn fastrand_u64() -> u64 {
+    // Lightweight entropy without adding a crate dependency.
+    let t = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    t.wrapping_mul(0x9e37_79b9_7f4a_7c15).wrapping_add(0x85eb_ca6b)
+}
+
+fn unix_ms_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Process-wide default store used by the Axum extractor when no state is injected.
+static GLOBAL_STORE: std::sync::OnceLock<SessionStore> = std::sync::OnceLock::new();
+
+/// Access (and lazily init) the global session store.
+pub fn global_session_store() -> &'static SessionStore {
+    GLOBAL_STORE.get_or_init(SessionStore::default)
+}
+
+/// Axum extractor: `Authorization: Bearer <session_id>`.
 ///
-/// The extractor treats the bearer token as the user's address string and
-/// returns `401 Unauthorized` when the header is missing or malformed. Handlers
-/// that want optional authentication may accept `Option<UserSession>` instead.
+/// Validates against [`global_session_store`], enforces idle timeout and
+/// key-version checks, and renews last-activity on success.
 #[async_trait]
 impl<S> FromRequestParts<S> for UserSession
 where
@@ -33,26 +474,122 @@ where
     type Rejection = (StatusCode, &'static str);
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        // Read the Authorization header
         let header_value = parts
             .headers
             .get(AUTHORIZATION)
             .and_then(|v| v.to_str().ok())
             .ok_or((StatusCode::UNAUTHORIZED, "missing authorization header"))?;
 
-        // Expect "Bearer <token>"
-        let mut parts = header_value.splitn(2, ' ');
-        let scheme = parts.next().unwrap_or("");
-        let token = parts.next().unwrap_or("");
+        let mut hdr = header_value.splitn(2, ' ');
+        let scheme = hdr.next().unwrap_or("");
+        let token = hdr.next().unwrap_or("");
 
         if !scheme.eq_ignore_ascii_case("bearer") || token.is_empty() {
             return Err((StatusCode::UNAUTHORIZED, "invalid authorization header"));
         }
 
-        // Minimal validation: token length and characters can be checked here.
-        // For now we treat the token as the canonical user address.
-        Ok(UserSession {
-            user_address: token.to_string(),
-        })
+        global_session_store()
+            .validate_and_touch(token)
+            .ok_or((StatusCode::UNAUTHORIZED, "invalid or expired session"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_session_rotates_away_from_pre_auth_id() {
+        let store = SessionStore::new(SessionConfig {
+            idle_timeout: Duration::from_secs(60),
+            max_sessions_per_user: 3,
+        });
+        let pre = "pre_auth_fixation_id";
+        // Plant a bogus pre-auth session entry so destroy path is exercised.
+        {
+            let mut sessions = store.inner.sessions.lock().unwrap();
+            sessions.insert(
+                pre.into(),
+                StoredSession {
+                    session_id: pre.into(),
+                    user_address: "GUSER".into(),
+                    key_version: 0,
+                    created_at: Instant::now(),
+                    last_activity: Instant::now(),
+                },
+            );
+        }
+        let session = store.create_session("GUSER", Some(pre));
+        assert_ne!(session.session_id, pre);
+        assert!(store.validate_and_touch(&session.session_id).is_some());
+        assert!(store.validate_and_touch(pre).is_none());
+    }
+
+    #[test]
+    fn idle_timeout_rejects_stale_session() {
+        let store = SessionStore::new(SessionConfig {
+            idle_timeout: Duration::from_millis(30),
+            max_sessions_per_user: 3,
+        });
+        let session = store.create_session("GUSER", None);
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(store.validate_and_touch(&session.session_id).is_none());
+        let kinds: Vec<_> = store
+            .activity_log()
+            .into_iter()
+            .map(|a| a.kind)
+            .collect();
+        assert!(kinds.contains(&SessionActivityKind::IdleTimeout));
+    }
+
+    #[test]
+    fn concurrent_session_limit_evicts_oldest() {
+        let store = SessionStore::new(SessionConfig {
+            idle_timeout: Duration::from_secs(60),
+            max_sessions_per_user: 2,
+        });
+        let s1 = store.create_session("GUSER", None);
+        let s2 = store.create_session("GUSER", None);
+        let s3 = store.create_session("GUSER", None);
+        assert!(store.validate_and_touch(&s1.session_id).is_none());
+        assert!(store.validate_and_touch(&s2.session_id).is_some());
+        assert!(store.validate_and_touch(&s3.session_id).is_some());
+        assert_eq!(store.active_session_count("GUSER"), 2);
+    }
+
+    #[test]
+    fn key_change_invalidates_all_sessions() {
+        let store = SessionStore::default();
+        let s1 = store.create_session("GUSER", None);
+        let s2 = store.create_session("GUSER", None);
+        store.invalidate_on_key_change("GUSER");
+        assert!(store.validate_and_touch(&s1.session_id).is_none());
+        assert!(store.validate_and_touch(&s2.session_id).is_none());
+        assert_eq!(store.active_session_count("GUSER"), 0);
+        let kinds: Vec<_> = store
+            .activity_log()
+            .into_iter()
+            .map(|a| a.kind)
+            .collect();
+        assert!(kinds.contains(&SessionActivityKind::InvalidatedKeyChange));
+    }
+
+    #[test]
+    fn logout_destroys_session_and_logs() {
+        let store = SessionStore::default();
+        let s = store.create_session("GUSER", None);
+        assert!(store.logout(&s.session_id));
+        assert!(store.validate_and_touch(&s.session_id).is_none());
+    }
+
+    #[test]
+    fn activity_log_records_create() {
+        let store = SessionStore::default();
+        store.create_session("GABC", None);
+        let log = store.activity_log();
+        assert!(log.iter().any(|a| a.kind == SessionActivityKind::Created));
+        assert!(log
+            .iter()
+            .any(|a| a.kind == SessionActivityKind::Authenticated));
     }
 }

--- a/backend/src/worker/mod.rs
+++ b/backend/src/worker/mod.rs
@@ -3,7 +3,11 @@
 //! Polls the Stellar RPC `getEvents` endpoint every ~5 seconds (one ledger),
 //! persists the latest processed ledger to the database so the worker can
 //! resume after a restart, and logs every batch of events found.
+//!
+//! [`queue`] adds dead-letter queues, exponential-backoff retries, idempotent
+//! job processing, and worker health snapshots.
 
+pub mod queue;
 pub mod stellar_listener;
 /// Full contract-DB state synchronisation task (#562).
 pub mod sync;

--- a/backend/src/worker/queue.rs
+++ b/backend/src/worker/queue.rs
@@ -1,0 +1,586 @@
+//! Reliable background job processing for the Stellar event worker.
+//!
+//! Provides:
+//! - Exponential backoff retry policies
+//! - Dead-letter queue (DLQ) for permanently failed jobs
+//! - Idempotent processing via a processed-job ID set
+//! - Worker health snapshots (last success, consecutive failures, DLQ depth)
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tracing::{error, info, warn};
+
+/// Default maximum delivery attempts before a job is dead-lettered.
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 5;
+/// Base delay (ms) for the first retry.
+pub const DEFAULT_BASE_DELAY_MS: u64 = 200;
+/// Cap on exponential backoff delay (ms).
+pub const DEFAULT_MAX_DELAY_MS: u64 = 30_000;
+/// Maximum retained DLQ entries (oldest dropped when exceeded).
+const DLQ_CAPACITY: usize = 1_000;
+/// Maximum retained processed job IDs for idempotency.
+const IDEMPOTENCY_CAPACITY: usize = 10_000;
+
+/// Retry policy with exponential backoff.
+#[derive(Debug, Clone, Copy)]
+pub struct RetryPolicy {
+    pub max_attempts: u32,
+    pub base_delay_ms: u64,
+    pub max_delay_ms: u64,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            base_delay_ms: DEFAULT_BASE_DELAY_MS,
+            max_delay_ms: DEFAULT_MAX_DELAY_MS,
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// Delay before attempt `n` (1-indexed). Attempt 1 has zero delay.
+    pub fn delay_before_attempt(&self, attempt: u32) -> Duration {
+        if attempt <= 1 {
+            return Duration::from_millis(0);
+        }
+        let shift = attempt.saturating_sub(2).min(16);
+        let ms = self
+            .base_delay_ms
+            .saturating_mul(2u64.saturating_pow(shift))
+            .min(self.max_delay_ms);
+        Duration::from_millis(ms)
+    }
+
+    /// Whether another attempt is allowed after `attempt` failures.
+    pub fn should_retry(&self, attempt: u32) -> bool {
+        attempt < self.max_attempts
+    }
+}
+
+/// A unit of work processed by the worker queue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Job {
+    /// Stable unique id used for idempotent delivery (e.g. Stellar event id).
+    pub id: String,
+    /// Logical job kind (e.g. `pool_created`, `prediction_placed`).
+    pub kind: String,
+    /// Opaque payload (typically JSON).
+    pub payload: String,
+    /// Delivery attempts so far (starts at 0 before first run).
+    pub attempts: u32,
+    /// Optional ledger for diagnostics.
+    pub ledger: Option<u64>,
+}
+
+/// Entry parked in the dead-letter queue after exhausting retries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeadLetterEntry {
+    pub job: Job,
+    pub last_error: String,
+    pub failed_at_unix_ms: u64,
+}
+
+/// Point-in-time health view for monitoring /health integrations.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkerHealth {
+    pub last_success_unix_ms: Option<u64>,
+    pub last_failure_unix_ms: Option<u64>,
+    pub consecutive_failures: u64,
+    pub jobs_processed: u64,
+    pub jobs_dead_lettered: u64,
+    pub dlq_depth: usize,
+    pub pending_retries: usize,
+    pub is_healthy: bool,
+}
+
+/// Shared reliable queue used by the Stellar listener.
+#[derive(Clone)]
+pub struct JobQueue {
+    inner: Arc<QueueInner>,
+}
+
+struct QueueInner {
+    policy: RetryPolicy,
+    /// Jobs waiting to be retried (id → next eligible Instant).
+    retry_after: Mutex<HashMap<String, Instant>>,
+    pending: Mutex<VecDeque<Job>>,
+    dlq: Mutex<VecDeque<DeadLetterEntry>>,
+    /// Recently processed job ids for duplicate-delivery safety.
+    processed: Mutex<HashSet<String>>,
+    processed_order: Mutex<VecDeque<String>>,
+    last_success_ms: AtomicU64,
+    last_failure_ms: AtomicU64,
+    consecutive_failures: AtomicU64,
+    jobs_processed: AtomicU64,
+    jobs_dead_lettered: AtomicU64,
+}
+
+impl JobQueue {
+    pub fn new(policy: RetryPolicy) -> Self {
+        Self {
+            inner: Arc::new(QueueInner {
+                policy,
+                retry_after: Mutex::new(HashMap::new()),
+                pending: Mutex::new(VecDeque::new()),
+                dlq: Mutex::new(VecDeque::new()),
+                processed: Mutex::new(HashSet::new()),
+                processed_order: Mutex::new(VecDeque::new()),
+                last_success_ms: AtomicU64::new(0),
+                last_failure_ms: AtomicU64::new(0),
+                consecutive_failures: AtomicU64::new(0),
+                jobs_processed: AtomicU64::new(0),
+                jobs_dead_lettered: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    pub fn with_defaults() -> Self {
+        Self::new(RetryPolicy::default())
+    }
+
+    pub fn policy(&self) -> RetryPolicy {
+        self.inner.policy
+    }
+
+    /// Returns `true` if this job id was already successfully processed.
+    pub fn already_processed(&self, job_id: &str) -> bool {
+        self.inner
+            .processed
+            .lock()
+            .expect("processed lock")
+            .contains(job_id)
+    }
+
+    /// Mark a job id as successfully processed (idempotency bookkeeping).
+    pub fn mark_processed(&self, job_id: &str) {
+        let mut processed = self.inner.processed.lock().expect("processed lock");
+        let mut order = self.inner.processed_order.lock().expect("order lock");
+        if processed.insert(job_id.to_string()) {
+            order.push_back(job_id.to_string());
+            while order.len() > IDEMPOTENCY_CAPACITY {
+                if let Some(old) = order.pop_front() {
+                    processed.remove(&old);
+                }
+            }
+        }
+    }
+
+    /// Enqueue a job for (re)processing. No-ops if already processed.
+    pub fn enqueue(&self, job: Job) -> bool {
+        if self.already_processed(&job.id) {
+            info!(job_id = %job.id, kind = %job.kind, "skipping duplicate job (idempotent)");
+            return false;
+        }
+        self.inner
+            .pending
+            .lock()
+            .expect("pending lock")
+            .push_back(job);
+        true
+    }
+
+    /// Pop the next ready job, respecting retry backoff windows.
+    pub fn dequeue_ready(&self) -> Option<Job> {
+        let now = Instant::now();
+        let mut pending = self.inner.pending.lock().expect("pending lock");
+        let retry_after = self.inner.retry_after.lock().expect("retry lock");
+
+        let mut skipped = VecDeque::new();
+        let mut found = None;
+        while let Some(job) = pending.pop_front() {
+            if let Some(ready_at) = retry_after.get(&job.id) {
+                if *ready_at > now {
+                    skipped.push_back(job);
+                    continue;
+                }
+            }
+            found = Some(job);
+            break;
+        }
+        for job in skipped {
+            pending.push_back(job);
+        }
+        found
+    }
+
+    /// Record a successful processing outcome.
+    pub fn record_success(&self, job: &Job) {
+        self.mark_processed(&job.id);
+        self.inner
+            .retry_after
+            .lock()
+            .expect("retry lock")
+            .remove(&job.id);
+        self.inner
+            .last_success_ms
+            .store(unix_ms_now(), Ordering::Relaxed);
+        self.inner
+            .consecutive_failures
+            .store(0, Ordering::Relaxed);
+        self.inner.jobs_processed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a failure: schedule retry or move to DLQ when attempts are exhausted.
+    pub fn record_failure(&self, mut job: Job, error: impl Into<String>) {
+        let error = error.into();
+        job.attempts = job.attempts.saturating_add(1);
+        self.inner
+            .last_failure_ms
+            .store(unix_ms_now(), Ordering::Relaxed);
+        self.inner
+            .consecutive_failures
+            .fetch_add(1, Ordering::Relaxed);
+
+        if self.inner.policy.should_retry(job.attempts) {
+            let delay = self.inner.policy.delay_before_attempt(job.attempts + 1);
+            warn!(
+                job_id = %job.id,
+                kind = %job.kind,
+                attempts = job.attempts,
+                delay_ms = delay.as_millis() as u64,
+                error = %error,
+                "job failed; scheduling retry"
+            );
+            self.inner
+                .retry_after
+                .lock()
+                .expect("retry lock")
+                .insert(job.id.clone(), Instant::now() + delay);
+            self.inner
+                .pending
+                .lock()
+                .expect("pending lock")
+                .push_back(job);
+        } else {
+            error!(
+                job_id = %job.id,
+                kind = %job.kind,
+                attempts = job.attempts,
+                error = %error,
+                "job exhausted retries; moving to dead-letter queue"
+            );
+            self.push_dlq(DeadLetterEntry {
+                job,
+                last_error: error,
+                failed_at_unix_ms: unix_ms_now(),
+            });
+        }
+    }
+
+    fn push_dlq(&self, entry: DeadLetterEntry) {
+        let mut dlq = self.inner.dlq.lock().expect("dlq lock");
+        if dlq.len() >= DLQ_CAPACITY {
+            dlq.pop_front();
+        }
+        dlq.push_back(entry);
+        self.inner
+            .jobs_dead_lettered
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Snapshot of DLQ contents (for ops / replay tooling).
+    pub fn dead_letters(&self) -> Vec<DeadLetterEntry> {
+        self.inner
+            .dlq
+            .lock()
+            .expect("dlq lock")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Re-queue a dead-lettered job for another attempt (clears attempt count).
+    pub fn requeue_from_dlq(&self, job_id: &str) -> bool {
+        let mut dlq = self.inner.dlq.lock().expect("dlq lock");
+        if let Some(pos) = dlq.iter().position(|e| e.job.id == job_id) {
+            let mut entry = dlq.remove(pos).expect("index valid");
+            entry.job.attempts = 0;
+            drop(dlq);
+            self.enqueue(entry.job);
+            return true;
+        }
+        false
+    }
+
+    /// Health snapshot for monitoring endpoints.
+    pub fn health(&self) -> WorkerHealth {
+        let consecutive = self.inner.consecutive_failures.load(Ordering::Relaxed);
+        let last_success = nonzero_ms(self.inner.last_success_ms.load(Ordering::Relaxed));
+        let last_failure = nonzero_ms(self.inner.last_failure_ms.load(Ordering::Relaxed));
+        let dlq_depth = self.inner.dlq.lock().expect("dlq lock").len();
+        let pending_retries = self.inner.pending.lock().expect("pending lock").len();
+
+        // Unhealthy if we have never succeeded and already failed, or many consecutive failures.
+        let is_healthy = consecutive < 5
+            && (last_success.is_some() || self.inner.jobs_processed.load(Ordering::Relaxed) == 0);
+
+        WorkerHealth {
+            last_success_unix_ms: last_success,
+            last_failure_unix_ms: last_failure,
+            consecutive_failures: consecutive,
+            jobs_processed: self.inner.jobs_processed.load(Ordering::Relaxed),
+            jobs_dead_lettered: self.inner.jobs_dead_lettered.load(Ordering::Relaxed),
+            dlq_depth,
+            pending_retries,
+            is_healthy,
+        }
+    }
+
+    /// Run `handler` with retry/DLQ/idempotency semantics for a single job.
+    pub async fn process_with_retry<F, Fut>(&self, mut job: Job, handler: F) -> Result<(), String>
+    where
+        F: Fn(Job) -> Fut,
+        Fut: std::future::Future<Output = Result<(), String>>,
+    {
+        if self.already_processed(&job.id) {
+            info!(job_id = %job.id, "idempotent skip");
+            return Ok(());
+        }
+
+        loop {
+            let delay = self.inner.policy.delay_before_attempt(job.attempts + 1);
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+
+            match handler(job.clone()).await {
+                Ok(()) => {
+                    self.record_success(&job);
+                    return Ok(());
+                }
+                Err(e) => {
+                    job.attempts = job.attempts.saturating_add(1);
+                    if !self.inner.policy.should_retry(job.attempts) {
+                        self.inner
+                            .last_failure_ms
+                            .store(unix_ms_now(), Ordering::Relaxed);
+                        self.inner
+                            .consecutive_failures
+                            .fetch_add(1, Ordering::Relaxed);
+                        self.push_dlq(DeadLetterEntry {
+                            job: job.clone(),
+                            last_error: e.clone(),
+                            failed_at_unix_ms: unix_ms_now(),
+                        });
+                        return Err(e);
+                    }
+                    warn!(
+                        job_id = %job.id,
+                        attempts = job.attempts,
+                        error = %e,
+                        "retrying job"
+                    );
+                    self.inner
+                        .last_failure_ms
+                        .store(unix_ms_now(), Ordering::Relaxed);
+                    self.inner
+                        .consecutive_failures
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+}
+
+fn unix_ms_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn nonzero_ms(v: u64) -> Option<u64> {
+    if v == 0 {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+/// Infer a job kind string from Stellar event topics.
+pub fn job_kind_from_topics(topics: Option<&Vec<String>>) -> String {
+    topics
+        .and_then(|t| {
+            t.iter()
+                .find(|s| {
+                    matches!(
+                        s.as_str(),
+                        "pool_created"
+                            | "prediction_placed"
+                            | "pool_resolved"
+                            | "pool_canceled"
+                            | "referral_paid"
+                    )
+                })
+                .cloned()
+        })
+        .unwrap_or_else(|| "unknown".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_is_exponential_and_capped() {
+        let policy = RetryPolicy {
+            max_attempts: 10,
+            base_delay_ms: 200,
+            max_delay_ms: 5_000,
+        };
+        assert_eq!(policy.delay_before_attempt(1), Duration::from_millis(0));
+        assert_eq!(policy.delay_before_attempt(2), Duration::from_millis(200));
+        assert_eq!(policy.delay_before_attempt(3), Duration::from_millis(400));
+        assert_eq!(policy.delay_before_attempt(4), Duration::from_millis(800));
+        assert_eq!(policy.delay_before_attempt(10), Duration::from_millis(5_000));
+    }
+
+    #[test]
+    fn should_retry_respects_max_attempts() {
+        let policy = RetryPolicy::default();
+        assert!(policy.should_retry(1));
+        assert!(policy.should_retry(4));
+        assert!(!policy.should_retry(5));
+    }
+
+    #[test]
+    fn idempotent_skip_on_duplicate_enqueue() {
+        let q = JobQueue::with_defaults();
+        let job = Job {
+            id: "evt-1".into(),
+            kind: "pool_created".into(),
+            payload: "{}".into(),
+            attempts: 0,
+            ledger: Some(1),
+        };
+        assert!(q.enqueue(job.clone()));
+        q.mark_processed("evt-1");
+        assert!(!q.enqueue(job));
+        assert!(q.already_processed("evt-1"));
+    }
+
+    #[test]
+    fn exhausted_retries_go_to_dlq() {
+        let q = JobQueue::new(RetryPolicy {
+            max_attempts: 2,
+            base_delay_ms: 1,
+            max_delay_ms: 1,
+        });
+        let job = Job {
+            id: "evt-fail".into(),
+            kind: "prediction_placed".into(),
+            payload: "{}".into(),
+            attempts: 0,
+            ledger: None,
+        };
+        q.record_failure(job.clone(), "boom");
+        assert_eq!(q.dead_letters().len(), 0); // first failure → retry
+        let mut retried = q.dequeue_ready().expect("pending retry");
+        retried.attempts = 1;
+        q.record_failure(retried, "boom again");
+        assert_eq!(q.dead_letters().len(), 1);
+        assert_eq!(q.health().jobs_dead_lettered, 1);
+    }
+
+    #[test]
+    fn requeue_from_dlq_resets_attempts() {
+        let q = JobQueue::new(RetryPolicy {
+            max_attempts: 1,
+            base_delay_ms: 1,
+            max_delay_ms: 1,
+        });
+        let job = Job {
+            id: "evt-dlq".into(),
+            kind: "pool_resolved".into(),
+            payload: "{}".into(),
+            attempts: 0,
+            ledger: None,
+        };
+        q.record_failure(job, "fatal");
+        assert_eq!(q.dead_letters().len(), 1);
+        assert!(q.requeue_from_dlq("evt-dlq"));
+        let again = q.dequeue_ready().expect("requeued");
+        assert_eq!(again.attempts, 0);
+        assert!(q.dead_letters().is_empty());
+    }
+
+    #[test]
+    fn health_reports_success() {
+        let q = JobQueue::with_defaults();
+        let job = Job {
+            id: "ok".into(),
+            kind: "pool_created".into(),
+            payload: "{}".into(),
+            attempts: 0,
+            ledger: None,
+        };
+        q.record_success(&job);
+        let h = q.health();
+        assert!(h.is_healthy);
+        assert_eq!(h.jobs_processed, 1);
+        assert_eq!(h.consecutive_failures, 0);
+        assert!(h.last_success_unix_ms.is_some());
+    }
+
+    #[tokio::test]
+    async fn process_with_retry_succeeds_after_transient_errors() {
+        let q = JobQueue::new(RetryPolicy {
+            max_attempts: 5,
+            base_delay_ms: 1,
+            max_delay_ms: 1,
+        });
+        let attempts = Arc::new(AtomicU64::new(0));
+        let attempts_c = attempts.clone();
+        let job = Job {
+            id: "retry-ok".into(),
+            kind: "test".into(),
+            payload: "{}".into(),
+            attempts: 0,
+            ledger: None,
+        };
+        let result = q
+            .process_with_retry(job, |_j| {
+                let c = attempts_c.clone();
+                async move {
+                    let n = c.fetch_add(1, Ordering::SeqCst) + 1;
+                    if n < 3 {
+                        Err("transient".into())
+                    } else {
+                        Ok(())
+                    }
+                }
+            })
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert!(q.already_processed("retry-ok"));
+    }
+
+    #[tokio::test]
+    async fn process_with_retry_dead_letters_on_permanent_failure() {
+        let q = JobQueue::new(RetryPolicy {
+            max_attempts: 2,
+            base_delay_ms: 1,
+            max_delay_ms: 1,
+        });
+        let job = Job {
+            id: "perm-fail".into(),
+            kind: "test".into(),
+            payload: "{}".into(),
+            attempts: 0,
+            ledger: None,
+        };
+        let result = q
+            .process_with_retry(job, |_j| async { Err("always".into()) })
+            .await;
+        assert!(result.is_err());
+        assert_eq!(q.dead_letters().len(), 1);
+        assert!(!q.already_processed("perm-fail"));
+    }
+}

--- a/backend/src/worker/stellar_listener.rs
+++ b/backend/src/worker/stellar_listener.rs
@@ -13,6 +13,17 @@ use tokio::time::interval;
 use tracing::{error, info, instrument, warn};
 
 use crate::redis_cache::RedisCache;
+use crate::worker::queue::{job_kind_from_topics, Job, JobQueue};
+
+use std::sync::OnceLock;
+
+/// Shared reliable job queue for idempotency, retries, DLQ, and health.
+static WORKER_QUEUE: OnceLock<JobQueue> = OnceLock::new();
+
+/// Access the process-wide worker job queue (for health endpoints / ops).
+pub fn worker_job_queue() -> &'static JobQueue {
+    WORKER_QUEUE.get_or_init(JobQueue::with_defaults)
+}
 
 const POLL_INTERVAL_SECS: u64 = 5;
 const STATE_KEY: &str = "stellar_listener_latest_ledger";
@@ -257,7 +268,9 @@ async fn process_event_batch(
     events: &[StellarEvent],
     max_batch_size: usize,
 ) {
+    let queue = worker_job_queue();
     let mut referral_events: Vec<crate::db::ReferralPaidEvent> = Vec::new();
+    let mut referral_job_ids: Vec<String> = Vec::new();
 
     for event in events {
         info!(
@@ -268,6 +281,12 @@ async fn process_event_batch(
             "stellar event"
         );
 
+        // Idempotent skip for duplicate deliveries of the same event id.
+        if queue.already_processed(&event.id) {
+            info!(id = %event.id, "skipping already-processed event");
+            continue;
+        }
+
         let topic_matches = |needle: &str| {
             event
                 .topics
@@ -277,64 +296,92 @@ async fn process_event_batch(
         };
 
         if event.event_type == "contract" {
+            let kind = job_kind_from_topics(event.topics.as_ref());
+            let job = Job {
+                id: event.id.clone(),
+                kind: kind.clone(),
+                payload: event
+                    .data
+                    .as_ref()
+                    .map(|d| d.to_string())
+                    .unwrap_or_default(),
+                attempts: 0,
+                ledger: Some(event.ledger),
+            };
+
             if topic_matches("pool_created") {
-                if let Err(e) = handle_pool_created_event(db, redis, event).await {
-                    error!(
-                        id = %event.id,
-                        ledger = event.ledger,
-                        error = %e,
-                        "failed to process pool_created event"
-                    );
+                match handle_pool_created_event(db, redis, event).await {
+                    Ok(()) => queue.record_success(&job),
+                    Err(e) => {
+                        error!(id = %event.id, ledger = event.ledger, error = %e, "failed to process pool_created event");
+                        queue.record_failure(job, e);
+                    }
                 }
             } else if topic_matches("prediction_placed") {
-                if let Err(e) = handle_prediction_placed_event(db, event, event_bus).await {
-                    error!(
-                        id = %event.id,
-                        ledger = event.ledger,
-                        error = %e,
-                        "failed to process prediction_placed event"
-                    );
+                match handle_prediction_placed_event(db, event, event_bus).await {
+                    Ok(()) => queue.record_success(&job),
+                    Err(e) => {
+                        error!(id = %event.id, ledger = event.ledger, error = %e, "failed to process prediction_placed event");
+                        queue.record_failure(job, e);
+                    }
                 }
             } else if topic_matches("pool_resolved") {
-                if let Err(e) = handle_pool_resolved_event(db, event).await {
-                    error!(
-                        id = %event.id,
-                        ledger = event.ledger,
-                        error = %e,
-                        "failed to process pool_resolved event"
-                    );
+                match handle_pool_resolved_event(db, event).await {
+                    Ok(()) => queue.record_success(&job),
+                    Err(e) => {
+                        error!(id = %event.id, ledger = event.ledger, error = %e, "failed to process pool_resolved event");
+                        queue.record_failure(job, e);
+                    }
                 }
             } else if topic_matches("pool_canceled") {
-                if let Err(e) = handle_pool_canceled_event(db, event).await {
-                    error!(
-                        id = %event.id,
-                        ledger = event.ledger,
-                        error = %e,
-                        "failed to process pool_canceled event"
-                    );
+                match handle_pool_canceled_event(db, event).await {
+                    Ok(()) => queue.record_success(&job),
+                    Err(e) => {
+                        error!(id = %event.id, ledger = event.ledger, error = %e, "failed to process pool_canceled event");
+                        queue.record_failure(job, e);
+                    }
                 }
             } else if topic_matches("referral_paid") {
                 match parse_referral_paid_event(event) {
-                    Ok(ev) => referral_events.push(ev),
-                    Err(e) => error!(
-                        id = %event.id,
-                        ledger = event.ledger,
-                        error = %e,
-                        "failed to parse referral_paid event"
-                    ),
+                    Ok(ev) => {
+                        referral_events.push(ev);
+                        referral_job_ids.push(event.id.clone());
+                    }
+                    Err(e) => {
+                        error!(id = %event.id, ledger = event.ledger, error = %e, "failed to parse referral_paid event");
+                        queue.record_failure(job, e);
+                    }
                 }
             }
         }
     }
 
     if !referral_events.is_empty() {
-        if let Err(e) = crate::db::insert_referrals_bulk(db, &referral_events, max_batch_size).await
-        {
-            error!(
-                error = %e,
-                count = referral_events.len(),
-                "failed to bulk insert referral events"
-            );
+        match crate::db::insert_referrals_bulk(db, &referral_events, max_batch_size).await {
+            Ok(()) => {
+                for id in &referral_job_ids {
+                    queue.mark_processed(id);
+                }
+            }
+            Err(e) => {
+                error!(
+                    error = %e,
+                    count = referral_events.len(),
+                    "failed to bulk insert referral events"
+                );
+                for id in referral_job_ids {
+                    queue.record_failure(
+                        Job {
+                            id,
+                            kind: "referral_paid".into(),
+                            payload: String::new(),
+                            attempts: 0,
+                            ledger: None,
+                        },
+                        e.to_string(),
+                    );
+                }
+            }
         }
     }
 }

--- a/frontend/components/WalletErrorBanner.tsx
+++ b/frontend/components/WalletErrorBanner.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { AlertTriangle, Wallet, XCircle, Clock, Coins } from "lucide-react";
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import type { WalletError, WalletErrorCode } from "@/lib/walletErrors";
+
+const ICONS: Record<WalletErrorCode, typeof AlertTriangle> = {
+  NETWORK_MISMATCH: AlertTriangle,
+  EXTENSION_NOT_INSTALLED: Wallet,
+  USER_REJECTED: XCircle,
+  TRANSACTION_TIMEOUT: Clock,
+  INSUFFICIENT_BALANCE: Coins,
+  UNKNOWN: AlertTriangle,
+};
+
+interface WalletErrorBannerProps {
+  error: WalletError;
+  onRetry?: () => void;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+/**
+ * Clear user-facing wallet error with recovery CTA.
+ */
+export function WalletErrorBanner({
+  error,
+  onRetry,
+  onDismiss,
+  className,
+}: WalletErrorBannerProps) {
+  const Icon = ICONS[error.code];
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "rounded-xl border border-zinc-800 bg-zinc-900/90 p-4 text-left shadow-lg",
+        className
+      )}
+    >
+      <div className="flex gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-500/10">
+          <Icon className="h-5 w-5 text-amber-400" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-white">{error.title}</p>
+          <p className="mt-1 text-sm text-zinc-400">{error.message}</p>
+          <p className="mt-2 text-sm text-zinc-300">{error.recoveryAction}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {onRetry && (
+              <Button type="button" size="small" onClick={onRetry}>
+                Try again
+              </Button>
+            )}
+            {error.code === "EXTENSION_NOT_INSTALLED" && (
+              <Button
+                type="button"
+                size="small"
+                variant="secondary"
+                onClick={() =>
+                  window.open("https://freighter.app", "_blank", "noopener,noreferrer")
+                }
+              >
+                Get Freighter
+              </Button>
+            )}
+            {onDismiss && (
+              <Button type="button" size="small" variant="ghost" onClick={onDismiss}>
+                Dismiss
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/modals/NetworkSwitchModal.tsx
+++ b/frontend/components/modals/NetworkSwitchModal.tsx
@@ -11,6 +11,7 @@ interface NetworkSwitchModalProps {
   currentChainName: string;
   onSwitch: () => Promise<void>;
   switchError: string | null;
+  switchRecoveryAction?: string | null;
 }
 
 export function NetworkSwitchModal({
@@ -18,6 +19,7 @@ export function NetworkSwitchModal({
   currentChainName,
   onSwitch,
   switchError,
+  switchRecoveryAction,
 }: NetworkSwitchModalProps) {
   const switchBtnRef = useRef<HTMLButtonElement>(null);
 
@@ -81,9 +83,12 @@ export function NetworkSwitchModal({
 
         {/* Error feedback */}
         {switchError && (
-          <p role="alert" className="mt-3 text-xs text-red-400">
-            {switchError}
-          </p>
+          <div role="alert" className="mt-3 space-y-1">
+            <p className="text-xs text-red-400">{switchError}</p>
+            {switchRecoveryAction && (
+              <p className="text-xs text-zinc-400">{switchRecoveryAction}</p>
+            )}
+          </div>
         )}
 
         {/* CTA */}

--- a/frontend/components/providers/NetworkGuardProvider.tsx
+++ b/frontend/components/providers/NetworkGuardProvider.tsx
@@ -5,8 +5,13 @@ import { useNetworkGuard } from "@/lib/hooks/useNetworkGuard";
 import { NetworkSwitchModal } from "@/components/modals/NetworkSwitchModal";
 
 export function NetworkGuardProvider({ children }: { children: ReactNode }) {
-  const { isWrongNetwork, currentChainName, switchNetwork, switchError } =
-    useNetworkGuard();
+  const {
+    isWrongNetwork,
+    currentChainName,
+    switchNetwork,
+    switchError,
+    switchRecoveryAction,
+  } = useNetworkGuard();
 
   return (
     <>
@@ -16,6 +21,7 @@ export function NetworkGuardProvider({ children }: { children: ReactNode }) {
         currentChainName={currentChainName}
         onSwitch={switchNetwork}
         switchError={switchError}
+        switchRecoveryAction={switchRecoveryAction}
       />
     </>
   );

--- a/frontend/lib/hooks/useNetworkGuard.ts
+++ b/frontend/lib/hooks/useNetworkGuard.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { classifyWalletError } from "@/lib/walletErrors";
 
 /** Stellar / Soroban — no canonical EVM chain for this app.
  *  Set to the chain you actually target; null means "any chain is wrong
@@ -18,6 +19,8 @@ export interface NetworkGuardState {
   switchNetwork: () => Promise<void>;
   /** Error message from the last failed switch attempt. */
   switchError: string | null;
+  /** Structured recovery hint when switch fails. */
+  switchRecoveryAction: string | null;
 }
 
 const CHAIN_NAMES: Record<string, string> = {
@@ -39,12 +42,14 @@ function chainName(hexId: string): string {
 export function useNetworkGuard(): NetworkGuardState {
   const [currentChainId, setCurrentChainId] = useState<string | null>(null);
   const [switchError, setSwitchError] = useState<string | null>(null);
+  const [switchRecoveryAction, setSwitchRecoveryAction] = useState<
+    string | null
+  >(null);
 
   useEffect(() => {
     const eth = window.ethereum;
     if (!eth) return;
 
-    // Read current chain on mount
     eth.request({ method: "eth_chainId" }).then(setCurrentChainId).catch(() => {});
 
     const handler = (chainId: string) => setCurrentChainId(chainId);
@@ -58,16 +63,25 @@ export function useNetworkGuard(): NetworkGuardState {
 
   const switchNetwork = useCallback(async () => {
     const eth = window.ethereum;
-    if (!eth) return;
+    if (!eth) {
+      const classified = classifyWalletError(
+        new Error("wallet extension not found")
+      );
+      setSwitchError(classified.message);
+      setSwitchRecoveryAction(classified.recoveryAction);
+      return;
+    }
     setSwitchError(null);
+    setSwitchRecoveryAction(null);
     try {
       await eth.request({
         method: "wallet_switchEthereumChain",
         params: [{ chainId: REQUIRED_CHAIN_ID }],
       });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Network switch failed.";
-      setSwitchError(msg);
+      const classified = classifyWalletError(err);
+      setSwitchError(classified.message);
+      setSwitchRecoveryAction(classified.recoveryAction);
     }
   }, []);
 
@@ -76,5 +90,6 @@ export function useNetworkGuard(): NetworkGuardState {
     currentChainName: currentChainId ? chainName(currentChainId) : "",
     switchNetwork,
     switchError,
+    switchRecoveryAction,
   };
 }

--- a/frontend/lib/hooks/useWalletConnection.ts
+++ b/frontend/lib/hooks/useWalletConnection.ts
@@ -1,0 +1,153 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  classifyWalletError,
+  checkNetworkMatch,
+  isStellarWalletInstalled,
+  makeWalletError,
+  withWalletTimeout,
+  type WalletError,
+  REQUIRED_STELLAR_NETWORK,
+  STELLAR_NETWORK_LABELS,
+} from "@/lib/walletErrors";
+
+export interface WalletConnectionState {
+  address: string | null;
+  isConnecting: boolean;
+  error: WalletError | null;
+  requiredNetworkLabel: string;
+  connect: () => Promise<string | null>;
+  disconnect: () => void;
+  clearError: () => void;
+}
+
+type FreighterLike = {
+  isConnected?: () => Promise<boolean>;
+  getNetwork?: () => Promise<string>;
+  getNetworkDetails?: () => Promise<{ network: string; networkPassphrase?: string }>;
+  getPublicKey?: () => Promise<string>;
+  requestAccess?: () => Promise<string>;
+};
+
+function getFreighterApi(): FreighterLike | null {
+  if (typeof window === "undefined") return null;
+  const w = window as Window & {
+    freighterApi?: FreighterLike;
+    freighter?: FreighterLike;
+  };
+  return w.freighterApi ?? w.freighter ?? null;
+}
+
+/**
+ * Connect / disconnect with structured error handling for:
+ * extension missing, network mismatch, user rejection, timeout.
+ */
+export function useWalletConnection(): WalletConnectionState {
+  const [address, setAddress] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<WalletError | null>(null);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const disconnect = useCallback(() => {
+    setAddress(null);
+    setError(null);
+  }, []);
+
+  const connect = useCallback(async (): Promise<string | null> => {
+    setIsConnecting(true);
+    setError(null);
+
+    try {
+      if (!isStellarWalletInstalled()) {
+        const err = makeWalletError("EXTENSION_NOT_INSTALLED");
+        setError(err);
+        return null;
+      }
+
+      const api = getFreighterApi();
+      if (!api) {
+        const err = makeWalletError("EXTENSION_NOT_INSTALLED");
+        setError(err);
+        return null;
+      }
+
+      // Network check before requesting access
+      try {
+        const network =
+          (await api.getNetworkDetails?.())?.network ??
+          (await api.getNetwork?.()) ??
+          null;
+        const mismatch = checkNetworkMatch(network);
+        if (mismatch) {
+          setError(mismatch);
+          return null;
+        }
+      } catch (netErr) {
+        // Some wallets throw if locked — classify rather than swallow.
+        const classified = classifyWalletError(netErr);
+        if (classified.code !== "UNKNOWN") {
+          setError(classified);
+          return null;
+        }
+      }
+
+      const publicKey = await withWalletTimeout(
+        (async () => {
+          if (api.requestAccess) {
+            return api.requestAccess();
+          }
+          if (api.getPublicKey) {
+            return api.getPublicKey();
+          }
+          throw makeWalletError("EXTENSION_NOT_INSTALLED");
+        })(),
+        60_000
+      );
+
+      if (!publicKey || typeof publicKey !== "string") {
+        const err = makeWalletError("USER_REJECTED");
+        setError(err);
+        return null;
+      }
+
+      setAddress(publicKey);
+      return publicKey;
+    } catch (err) {
+      // withWalletTimeout may reject with a WalletError directly
+      if (
+        err &&
+        typeof err === "object" &&
+        "code" in err &&
+        "recoveryAction" in err
+      ) {
+        setError(err as WalletError);
+        return null;
+      }
+      const classified = classifyWalletError(err);
+      setError(classified);
+      return null;
+    } finally {
+      setIsConnecting(false);
+    }
+  }, []);
+
+  return {
+    address,
+    isConnecting,
+    error,
+    requiredNetworkLabel: STELLAR_NETWORK_LABELS[REQUIRED_STELLAR_NETWORK],
+    connect,
+    disconnect,
+    clearError,
+  };
+}
+
+/**
+ * Classify a transaction submission failure (balance, timeout, reject).
+ * Use around contract invoke / payment submits.
+ */
+export function handleTransactionError(err: unknown): WalletError {
+  return classifyWalletError(err);
+}

--- a/frontend/lib/walletErrors.ts
+++ b/frontend/lib/walletErrors.ts
@@ -1,0 +1,245 @@
+/**
+ * Wallet connection error taxonomy and user-facing recovery helpers.
+ *
+ * Covers: network mismatch, missing extension, user rejection,
+ * transaction timeout, and insufficient balance.
+ */
+
+export type WalletErrorCode =
+  | "NETWORK_MISMATCH"
+  | "EXTENSION_NOT_INSTALLED"
+  | "USER_REJECTED"
+  | "TRANSACTION_TIMEOUT"
+  | "INSUFFICIENT_BALANCE"
+  | "UNKNOWN";
+
+export interface WalletError {
+  code: WalletErrorCode;
+  /** Short title for toasts / modals */
+  title: string;
+  /** User-facing explanation */
+  message: string;
+  /** Concrete next step the user can take */
+  recoveryAction: string;
+  /** Original error when available */
+  cause?: unknown;
+}
+
+/** Expected Stellar network for PrediFi (override via env). */
+export type StellarNetwork = "TESTNET" | "PUBLIC" | "FUTURENET";
+
+export const REQUIRED_STELLAR_NETWORK: StellarNetwork =
+  (process.env.NEXT_PUBLIC_STELLAR_NETWORK as StellarNetwork) || "TESTNET";
+
+export const STELLAR_NETWORK_LABELS: Record<StellarNetwork, string> = {
+  TESTNET: "Stellar Testnet",
+  PUBLIC: "Stellar Mainnet",
+  FUTURENET: "Stellar Futurenet",
+};
+
+const WALLET_ERRORS: Record<
+  Exclude<WalletErrorCode, "UNKNOWN">,
+  Omit<WalletError, "code" | "cause">
+> = {
+  NETWORK_MISMATCH: {
+    title: "Wrong network",
+    message: `Your wallet is on a different network than PrediFi expects (${STELLAR_NETWORK_LABELS[REQUIRED_STELLAR_NETWORK]}).`,
+    recoveryAction: `Switch your wallet to ${STELLAR_NETWORK_LABELS[REQUIRED_STELLAR_NETWORK]}, then try again.`,
+  },
+  EXTENSION_NOT_INSTALLED: {
+    title: "Wallet not found",
+    message:
+      "No compatible wallet extension was detected. PrediFi needs Freighter (or another Stellar wallet) installed in your browser.",
+    recoveryAction:
+      "Install Freighter from https://freighter.app, refresh this page, then connect again.",
+  },
+  USER_REJECTED: {
+    title: "Connection cancelled",
+    message: "You rejected the wallet request in your extension.",
+    recoveryAction: "Open your wallet and approve the connection when prompted.",
+  },
+  TRANSACTION_TIMEOUT: {
+    title: "Request timed out",
+    message:
+      "The wallet did not respond in time. The network may be congested or the extension may be locked.",
+    recoveryAction:
+      "Unlock your wallet, check your connection, then retry the transaction.",
+  },
+  INSUFFICIENT_BALANCE: {
+    title: "Insufficient balance",
+    message:
+      "Your account does not have enough funds (including fees) to complete this action.",
+    recoveryAction:
+      "Add funds to your wallet on the correct network, then try again.",
+  },
+};
+
+export function makeWalletError(
+  code: Exclude<WalletErrorCode, "UNKNOWN">,
+  cause?: unknown
+): WalletError {
+  return { code, ...WALLET_ERRORS[code], cause };
+}
+
+export function unknownWalletError(cause?: unknown): WalletError {
+  const msg =
+    cause instanceof Error
+      ? cause.message
+      : typeof cause === "string"
+        ? cause
+        : "An unexpected wallet error occurred.";
+  return {
+    code: "UNKNOWN",
+    title: "Wallet error",
+    message: msg,
+    recoveryAction: "Refresh the page and try connecting again.",
+    cause,
+  };
+}
+
+/** Common wallet / RPC error code shapes (Freighter, MetaMask-style, Stellar). */
+function extractRawCode(err: unknown): string | number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const e = err as Record<string, unknown>;
+  if (typeof e.code === "string" || typeof e.code === "number") return e.code;
+  if (e.error && typeof e.error === "object") {
+    const nested = e.error as Record<string, unknown>;
+    if (typeof nested.code === "string" || typeof nested.code === "number") {
+      return nested.code;
+    }
+  }
+  return undefined;
+}
+
+function extractMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  if (err && typeof err === "object" && "message" in err) {
+    const m = (err as { message: unknown }).message;
+    if (typeof m === "string") return m;
+  }
+  return "";
+}
+
+/**
+ * Map a raw wallet/provider error into a structured {@link WalletError}.
+ */
+export function classifyWalletError(err: unknown): WalletError {
+  const code = extractRawCode(err);
+  const message = extractMessage(err).toLowerCase();
+
+  // User rejection (EIP-1193 4001, Freighter cancel, etc.)
+  if (
+    code === 4001 ||
+    code === "USER_REJECTED" ||
+    code === "action_rejected" ||
+    message.includes("user rejected") ||
+    message.includes("user denied") ||
+    message.includes("rejected by user") ||
+    message.includes("user cancelled") ||
+    message.includes("user canceled")
+  ) {
+    return makeWalletError("USER_REJECTED", err);
+  }
+
+  // Extension missing
+  if (
+    code === 4100 ||
+    message.includes("no provider") ||
+    message.includes("freighter is not installed") ||
+    message.includes("wallet not found") ||
+    message.includes("extension not") ||
+    message.includes("provider not found")
+  ) {
+    return makeWalletError("EXTENSION_NOT_INSTALLED", err);
+  }
+
+  // Network mismatch
+  if (
+    code === 4902 ||
+    message.includes("chain mismatch") ||
+    message.includes("wrong network") ||
+    message.includes("network mismatch") ||
+    message.includes("incorrect network") ||
+    message.includes("unsupported network")
+  ) {
+    return makeWalletError("NETWORK_MISMATCH", err);
+  }
+
+  // Timeout
+  if (
+    message.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("deadline exceeded")
+  ) {
+    return makeWalletError("TRANSACTION_TIMEOUT", err);
+  }
+
+  // Insufficient balance / funds
+  if (
+    message.includes("insufficient") ||
+    message.includes("not enough") ||
+    message.includes("underfunded") ||
+    message.includes("balance too low") ||
+    message.includes("op_underfunded")
+  ) {
+    return makeWalletError("INSUFFICIENT_BALANCE", err);
+  }
+
+  return unknownWalletError(err);
+}
+
+/** Detect whether a Stellar wallet extension appears available. */
+export function isStellarWalletInstalled(): boolean {
+  if (typeof window === "undefined") return false;
+  const w = window as Window & {
+    freighter?: unknown;
+    freighterApi?: unknown;
+    stellar?: unknown;
+  };
+  return Boolean(w.freighter || w.freighterApi || w.stellar);
+}
+
+/**
+ * Compare the wallet-reported network passphrase / name to the required one.
+ * Returns a NETWORK_MISMATCH error when they differ.
+ */
+export function checkNetworkMatch(
+  walletNetwork: string | null | undefined
+): WalletError | null {
+  if (!walletNetwork) return null;
+  const normalized = walletNetwork.toUpperCase().replace(/\s+/g, "");
+  const required = REQUIRED_STELLAR_NETWORK;
+  const aliases: Record<StellarNetwork, string[]> = {
+    TESTNET: ["TESTNET", "TESTNETNETWORK", "STELLARTESTNET"],
+    PUBLIC: ["PUBLIC", "MAINNET", "PUBLICNETWORK", "STELLARPUBLIC"],
+    FUTURENET: ["FUTURENET", "FUTURENETNETWORK"],
+  };
+  const ok = aliases[required].some((a) => normalized.includes(a));
+  if (!ok) {
+    return makeWalletError("NETWORK_MISMATCH", { walletNetwork, required });
+  }
+  return null;
+}
+
+/**
+ * Wrap a wallet promise with a timeout; rejects with TRANSACTION_TIMEOUT.
+ */
+export async function withWalletTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs = 60_000
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(makeWalletError("TRANSACTION_TIMEOUT"));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION


### PR description

## Summary

Hardens backend worker reliability and session security, improves frontend wallet connection error UX, and adds a dedicated smart-contract CI/CD pipeline with testnet deploy on `develop`.

## Task 1 — Backend: Worker queue reliability

**Files:** `backend/src/worker/queue.rs`, `backend/src/worker/mod.rs`, `backend/src/worker/stellar_listener.rs`

- Added `JobQueue` with:
  - **Exponential backoff** retry policy (`RetryPolicy`: base 200ms, cap 30s, max 5 attempts)
  - **Dead-letter queue** for jobs that exhaust retries (bounded, requeueable)
  - **Idempotent processing** via processed-job ID set (dedupes duplicate Stellar event deliveries)
  - **Worker health snapshot** (`WorkerHealth`: last success/failure, consecutive failures, DLQ depth, pending retries)
- Wired the Stellar listener so each contract event is tracked as a job: success → mark processed; failure → retry/DLQ; duplicates skipped
- Referral bulk inserts only mark IDs processed after successful DB write; failures go to DLQ
- Unit tests cover backoff, idempotency, DLQ, requeue, and `process_with_retry`

**Ops:** `stellar_listener::worker_job_queue().health()` for monitoring hooks.

## Task 2 — Backend: Session management hardening

**File:** `backend/src/session.rs`

- **Session fixation prevention:** `create_session()` always issues a new `session_id` and discards any pre-auth id
- **Idle timeout:** default 30 minutes; expired sessions rejected and logged
- **Concurrent session limits:** default max 5 per user; oldest evicted
- **Invalidation on key/password change:** `invalidate_on_key_change()` bumps key version and destroys all user sessions
- **Activity audit log:** create / authenticate / renew / idle / evict / key-change / logout events (tracing + in-memory log)
- Axum extractor now validates `Authorization: Bearer <session_id>` against the store (not a raw address passthrough)
- Unit tests for fixation, idle timeout, concurrency, key-change invalidation, logout, and activity logging

## Task 3 — Frontend: Wallet connection error handling

**Files:**
- `frontend/lib/walletErrors.ts` — error taxonomy + classifiers
- `frontend/lib/hooks/useWalletConnection.ts` — connect flow with checks/timeout
- `frontend/components/WalletErrorBanner.tsx` — user-facing banner + recovery CTAs
- Updated `useNetworkGuard`, `NetworkSwitchModal`, `NetworkGuardProvider`

Handles with clear messages + recovery actions:

| Error | Recovery |
|-------|----------|
| Network mismatch | Switch to required Stellar network |
| Extension not installed | Install Freighter link |
| User rejection | Approve in wallet and retry |
| Transaction timeout | Unlock wallet / retry |
| Insufficient balance | Add funds and retry |

`classifyWalletError()` maps Freighter/EIP-1193-style codes and message patterns. `withWalletTimeout()` wraps wallet promises (default 60s).

## Task 4 — DevOps: Smart contract CI/CD

**File:** `.github/workflows/contract-ci.yml`

Jobs on `contract/**` changes (PRs + pushes to `main`/`develop`):

1. `cargo check` (wasm32)
2. `cargo fmt --check`
3. `cargo clippy` (`-D warnings`)
4. `cargo test --workspace`
5. **WASM build verification** (release build + `wasm-opt` + size threshold)
6. **Deploy to testnet** — only on push to `develop`, after all checks pass  
   - Uses `contract/scripts/deploy.sh testnet ci-deploy`  
   - Requires GitHub secret `STELLAR_TESTNET_SECRET_KEY` and environment `testnet`

## Test plan

- [ ] `cargo test --manifest-path backend/Cargo.toml worker::queue` / session tests (once pre-existing lib build issues are unrelated/resolved)
- [ ] Simulate duplicate Stellar event id → second delivery skipped
- [ ] Force handler failure → job retries then lands in DLQ; `requeue_from_dlq` works
- [ ] Create >5 sessions for one user → oldest invalidated
- [ ] Idle past timeout → `401` / validate returns `None`
- [ ] `invalidate_on_key_change` → all sessions dead
- [ ] Frontend: connect without Freighter → extension error + “Get Freighter”
- [ ] Reject connect → user-rejected message
- [ ] Wrong network / timeout / underfunded strings classify correctly
- [ ] Push/PR touching `contract/**` runs new workflow; merge to `develop` triggers deploy when secret is set

## Notes

- Branch: `backend-hardening`
- No commit/push performed
- Pre-existing codebase compile issues were left untouched

closes #1382 
closes #1383
closes #1384 
closes #1394