### PR TITLE
Batch token whitelist, multi-outcome pools, leaderboard views, and social sharing

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -845,6 +845,163 @@ pub async fn get_users_by_winnings(
     Ok(rankings)
 }
 
+/// A leaderboard entry supporting time-window and pool-scoped ranking (#1363).
+#[derive(Debug, serde::Serialize)]
+pub struct LeaderboardEntry {
+    pub user_address: String,
+    pub total_volume: i64,
+    pub prediction_count: i64,
+    pub wins: i64,
+    pub settled_count: i64,
+    pub win_rate: f64,
+    pub current_streak: i64,
+    pub rank: i64,
+}
+
+#[derive(sqlx::FromRow)]
+struct LeaderboardRow {
+    user_address: String,
+    total_volume: i64,
+    prediction_count: i64,
+    wins: i64,
+    settled_count: i64,
+    current_streak: i64,
+}
+
+/// Get leaderboard rankings with support for time-window filtering and
+/// optional per-pool scoping.
+///
+/// * `rank_by` - "volume" (default) | "win_rate" | "streak"
+/// * `period` - "week" | "month" | "all" (default)
+/// * `pool_id` - when `Some`, restricts the ranking to a single pool
+///
+/// `current_streak` counts each user's most recent consecutive wins across
+/// settled predictions (in the scope defined by `pool_id`/`period`), ordered
+/// by the pool's `end_time`.
+pub async fn get_leaderboard_extended(
+    pool: &PgPool,
+    rank_by: &str,
+    period: &str,
+    pool_id: Option<i64>,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<LeaderboardEntry>, sqlx::Error> {
+    let order_by = match rank_by {
+        "win_rate" => {
+            "(CASE WHEN ua.settled_count > 0 THEN ua.wins::FLOAT / ua.settled_count ELSE 0 END)"
+        }
+        "streak" => "COALESCE(sc.current_streak, 0)",
+        _ => "ua.total_volume",
+    };
+
+    let sql = format!(
+        r#"
+        WITH scoped_predictions AS (
+            SELECT p.user_address, p.pool_id, p.amount, p.outcome, p.created_at,
+                   pl.state, pl.result, pl.end_time
+            FROM predictions p
+            JOIN pools pl ON pl.pool_id = p.pool_id
+            WHERE ($3::bigint IS NULL OR p.pool_id = $3)
+              AND ($4::timestamptz IS NULL OR p.created_at >= $4)
+        ),
+        outcome_flags AS (
+            SELECT
+                user_address,
+                amount,
+                end_time,
+                state,
+                CASE
+                    WHEN state = 'settled' AND result IS NOT NULL AND outcome = CAST(result AS INTEGER)
+                    THEN 1 ELSE 0
+                END AS is_win
+            FROM scoped_predictions
+        ),
+        user_agg AS (
+            SELECT
+                user_address,
+                SUM(amount) AS total_volume,
+                COUNT(*) AS prediction_count,
+                SUM(CASE WHEN state = 'settled' THEN 1 ELSE 0 END) AS settled_count,
+                SUM(is_win) AS wins
+            FROM outcome_flags
+            GROUP BY user_address
+        ),
+        ranked_settled AS (
+            SELECT
+                user_address,
+                is_win,
+                ROW_NUMBER() OVER (PARTITION BY user_address ORDER BY end_time DESC) AS rn
+            FROM outcome_flags
+            WHERE state = 'settled'
+        ),
+        streak_groups AS (
+            SELECT
+                user_address,
+                is_win,
+                rn,
+                SUM(CASE WHEN is_win = 0 THEN 1 ELSE 0 END)
+                    OVER (PARTITION BY user_address ORDER BY rn) AS loss_group
+            FROM ranked_settled
+        ),
+        streak_calc AS (
+            SELECT user_address, COUNT(*) AS current_streak
+            FROM streak_groups
+            WHERE is_win = 1 AND loss_group = 0
+            GROUP BY user_address
+        )
+        SELECT
+            ua.user_address,
+            ua.total_volume,
+            ua.prediction_count,
+            COALESCE(ua.wins, 0) AS wins,
+            COALESCE(ua.settled_count, 0) AS settled_count,
+            COALESCE(sc.current_streak, 0) AS current_streak
+        FROM user_agg ua
+        LEFT JOIN streak_calc sc ON sc.user_address = ua.user_address
+        ORDER BY {order_by} DESC
+        LIMIT $1 OFFSET $2
+        "#
+    );
+
+    let cutoff: Option<DateTime<Utc>> = match period {
+        "week" => Some(Utc::now() - chrono::Duration::days(7)),
+        "month" => Some(Utc::now() - chrono::Duration::days(30)),
+        _ => None,
+    };
+
+    let rows = sqlx::query_as::<_, LeaderboardRow>(&sql)
+        .bind(limit)
+        .bind(offset)
+        .bind(pool_id)
+        .bind(cutoff)
+        .fetch_all(pool)
+        .await?;
+
+    let rankings = rows
+        .into_iter()
+        .enumerate()
+        .map(|(index, row)| {
+            let win_rate = if row.settled_count > 0 {
+                row.wins as f64 / row.settled_count as f64
+            } else {
+                0.0
+            };
+            LeaderboardEntry {
+                user_address: row.user_address,
+                total_volume: row.total_volume,
+                prediction_count: row.prediction_count,
+                wins: row.wins,
+                settled_count: row.settled_count,
+                win_rate,
+                current_streak: row.current_streak,
+                rank: offset + index as i64 + 1,
+            }
+        })
+        .collect();
+
+    Ok(rankings)
+}
+
 /// Run `operation` inside a database transaction, committing on success.
 #[instrument(skip(pool), name = "db.insert_prediction_from_event_with_pool",
     fields(pool_id = event.pool_id, user_address = %event.user_address))]

--- a/backend/src/routes/v1.rs
+++ b/backend/src/routes/v1.rs
@@ -535,14 +535,140 @@ pub struct LeaderboardQuery {
     pub limit: Option<BoundedI64<1, 100>>,
     /// Zero-based offset for pagination (default 0).
     pub offset: Option<BoundedI64<0, 9223372036854775807>>,
-    /// Ranking type: "volume" | "winnings" (default: "volume")
+    /// Ranking type: "volume" | "winnings" | "win_rate" | "streak" (default: "volume")
     pub rank_by: Option<NonEmptyString>,
+    /// Time window: "week" | "month" | "all" (default: "all"). Ignored for `rank_by=winnings`.
+    pub period: Option<NonEmptyString>,
 }
 
-/// `GET /api/v1/leaderboard` — user rankings by betting volume or winnings.
+/// `GET /api/v1/leaderboard` — user rankings by betting volume, winnings, win
+/// rate, or current win streak, optionally scoped to a time window
+/// ("week" | "month" | "all").
 pub async fn get_leaderboard(
     State(state): State<AppState>,
     Query(params): Query<LeaderboardQuery>,
+) -> axum::response::Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    let limit = params.limit.map(|b| b.get()).unwrap_or(20);
+    let offset = params.offset.map(|b| b.get()).unwrap_or(0);
+    let rank_by = params.rank_by.as_ref().map(|s| s.as_str()).unwrap_or("volume");
+    let period = params.period.as_ref().map(|s| s.as_str()).unwrap_or("all");
+
+    let Some(db) = &state.db else {
+        return ApiResponse::<()>::error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            error_codes::DATABASE_UNAVAILABLE,
+            "database not available",
+        )
+        .into_response();
+    };
+
+    match rank_by {
+        "winnings" => match crate::db::get_users_by_winnings(db, limit, offset).await {
+            Ok(users) => {
+                let response = json!({
+                    "leaderboard": users,
+                    "rank_by": "winnings",
+                    "period": "all",
+                    "limit": limit,
+                    "offset": offset,
+                });
+                ApiResponse::success(response).into_response()
+            }
+            Err(e) => ApiResponse::<()>::error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                error_codes::INTERNAL_ERROR,
+                e.to_string(),
+            )
+            .into_response(),
+        },
+        "win_rate" | "streak" => {
+            match crate::db::get_leaderboard_extended(db, rank_by, period, None, limit, offset)
+                .await
+            {
+                Ok(entries) => {
+                    let response = json!({
+                        "leaderboard": entries,
+                        "rank_by": rank_by,
+                        "period": period,
+                        "limit": limit,
+                        "offset": offset,
+                    });
+                    ApiResponse::success(response).into_response()
+                }
+                Err(e) => ApiResponse::<()>::error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    error_codes::INTERNAL_ERROR,
+                    e.to_string(),
+                )
+                .into_response(),
+            }
+        }
+        _ if period != "all" => {
+            // Volume ranking scoped to a time window.
+            match crate::db::get_leaderboard_extended(db, "volume", period, None, limit, offset)
+                .await
+            {
+                Ok(entries) => {
+                    let response = json!({
+                        "leaderboard": entries,
+                        "rank_by": "volume",
+                        "period": period,
+                        "limit": limit,
+                        "offset": offset,
+                    });
+                    ApiResponse::success(response).into_response()
+                }
+                Err(e) => ApiResponse::<()>::error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    error_codes::INTERNAL_ERROR,
+                    e.to_string(),
+                )
+                .into_response(),
+            }
+        }
+        _ => {
+            // Default: all-time volume ranking (unchanged legacy behavior).
+            match crate::db::get_users_by_betting_volume(db, limit, offset).await {
+                Ok(users) => {
+                    let response = json!({
+                        "leaderboard": users,
+                        "rank_by": "volume",
+                        "period": "all",
+                        "limit": limit,
+                        "offset": offset,
+                    });
+                    ApiResponse::success(response).into_response()
+                }
+                Err(e) => ApiResponse::<()>::error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    error_codes::INTERNAL_ERROR,
+                    e.to_string(),
+                )
+                .into_response(),
+            }
+        }
+    }
+}
+
+/// Query parameters for the `GET /api/v1/pools/:id/leaderboard` endpoint.
+#[derive(Debug, Deserialize)]
+pub struct PoolLeaderboardQuery {
+    /// Maximum number of results to return (capped at 100, default 20).
+    pub limit: Option<BoundedI64<1, 100>>,
+    /// Zero-based offset for pagination (default 0).
+    pub offset: Option<BoundedI64<0, 9223372036854775807>>,
+    /// Ranking type: "volume" | "win_rate" | "streak" (default: "volume")
+    pub rank_by: Option<NonEmptyString>,
+}
+
+/// `GET /api/v1/pools/:id/leaderboard` — top stakers for a single pool.
+pub async fn get_pool_leaderboard(
+    State(state): State<AppState>,
+    Path(pool_id): Path<i64>,
+    Query(params): Query<PoolLeaderboardQuery>,
 ) -> axum::response::Response {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
@@ -560,44 +686,25 @@ pub async fn get_leaderboard(
         .into_response();
     };
 
-    match rank_by {
-        "winnings" => match crate::db::get_users_by_winnings(db, limit, offset).await {
-            Ok(users) => {
-                let response = json!({
-                    "leaderboard": users,
-                    "rank_by": "winnings",
-                    "limit": limit,
-                    "offset": offset,
-                });
-                ApiResponse::success(response).into_response()
-            }
-            Err(e) => ApiResponse::<()>::error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                error_codes::INTERNAL_ERROR,
-                e.to_string(),
-            )
-            .into_response(),
-        },
-        _ => {
-            // Default to volume ranking
-            match crate::db::get_users_by_betting_volume(db, limit, offset).await {
-                Ok(users) => {
-                    let response = json!({
-                        "leaderboard": users,
-                        "rank_by": "volume",
-                        "limit": limit,
-                        "offset": offset,
-                    });
-                    ApiResponse::success(response).into_response()
-                }
-                Err(e) => ApiResponse::<()>::error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    error_codes::INTERNAL_ERROR,
-                    e.to_string(),
-                )
-                .into_response(),
-            }
+    match crate::db::get_leaderboard_extended(db, rank_by, "all", Some(pool_id), limit, offset)
+        .await
+    {
+        Ok(entries) => {
+            let response = json!({
+                "pool_id": pool_id,
+                "leaderboard": entries,
+                "rank_by": rank_by,
+                "limit": limit,
+                "offset": offset,
+            });
+            ApiResponse::success(response).into_response()
         }
+        Err(e) => ApiResponse::<()>::error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            error_codes::INTERNAL_ERROR,
+            e.to_string(),
+        )
+        .into_response(),
     }
 }
 
@@ -952,6 +1059,7 @@ pub fn router(
         Router::new()
             .route("/pools", get(get_pools))
             .route("/pools/:id", get(get_pool_by_id_handler))
+            .route("/pools/:id/leaderboard", get(get_pool_leaderboard))
             .route("/stats", get(get_stats))
             .route("/leaderboard", get(get_leaderboard))
             .route("/referrals/{address}", get(referrals_handler))
@@ -991,6 +1099,7 @@ pub fn router(
         .route("/health", get(health))
         .route("/pools", get(get_pools))
         .route("/pools/:id", get(get_pool_by_id_handler))
+        .route("/pools/:id/leaderboard", get(get_pool_leaderboard))
         .route("/leaderboard", get(get_leaderboard))
         .route("/fees", get(get_fees))
         .route("/prices", get(crate::price_cache::get_prices))

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -2529,6 +2529,131 @@ impl PredifiContract {
         Ok(())
     }
 
+    /// Batch add multiple tokens to the allowed betting whitelist in a single
+    /// transaction. Caller must have Admin role (0).
+    ///
+    /// Reduces per-token transaction overhead when onboarding several tokens
+    /// at once. Skips tokens that are already whitelisted.
+    ///
+    /// # Errors
+    /// * `Unauthorized` - If caller does not hold the Admin role.
+    /// * `InvalidData` - If `tokens` is empty or exceeds `MAX_BATCH_SIZE` (100).
+    pub fn batch_add_tokens_to_whitelist(
+        env: Env,
+        admin: Address,
+        tokens: Vec<Address>,
+    ) -> Result<u32, PredifiError> {
+        const MAX_BATCH_SIZE: u32 = 100;
+
+        Self::require_not_paused(&env)?;
+        admin.require_auth();
+        Self::require_admin_role(&env, &admin, "batch_add_tokens_to_whitelist")?;
+
+        let batch_size = tokens.len();
+        if batch_size == 0 || batch_size > MAX_BATCH_SIZE {
+            return Err(PredifiError::InvalidData);
+        }
+
+        let whitelist_key = DataKey::TokenWhitelist;
+        let mut whitelist: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&whitelist_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut added_count: u32 = 0;
+        for token in tokens.iter() {
+            let key = DataKey::TokenWl(token.clone());
+            let already_whitelisted = env.storage().persistent().has(&key);
+
+            if !already_whitelisted {
+                env.storage().persistent().set(&key, &true);
+                Self::extend_persistent(&env, &key);
+
+                if !whitelist.contains(&token) {
+                    whitelist.push_back(token.clone());
+                }
+
+                added_count += 1;
+
+                TokenWhitelistAddedEvent {
+                    admin: admin.clone(),
+                    token: token.clone(),
+                }
+                .publish(&env);
+            }
+        }
+
+        if added_count > 0 {
+            env.storage().persistent().set(&whitelist_key, &whitelist);
+            Self::extend_persistent(&env, &whitelist_key);
+        }
+
+        Ok(added_count)
+    }
+
+    /// Batch remove multiple tokens from the allowed betting whitelist in a
+    /// single transaction. Caller must have Admin role (0).
+    ///
+    /// # Errors
+    /// * `Unauthorized` - If caller does not hold the Admin role.
+    /// * `InvalidData` - If `tokens` is empty or exceeds `MAX_BATCH_SIZE` (100).
+    pub fn batch_remove_tokens_from_whitelist(
+        env: Env,
+        admin: Address,
+        tokens: Vec<Address>,
+    ) -> Result<u32, PredifiError> {
+        const MAX_BATCH_SIZE: u32 = 100;
+
+        Self::require_not_paused(&env)?;
+        admin.require_auth();
+        Self::require_admin_role(&env, &admin, "batch_remove_tokens_from_whitelist")?;
+
+        let batch_size = tokens.len();
+        if batch_size == 0 || batch_size > MAX_BATCH_SIZE {
+            return Err(PredifiError::InvalidData);
+        }
+
+        let whitelist_key = DataKey::TokenWhitelist;
+        let mut whitelist: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&whitelist_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut removed_count: u32 = 0;
+        for token in tokens.iter() {
+            let key = DataKey::TokenWl(token.clone());
+            let was_whitelisted = env.storage().persistent().has(&key);
+
+            if was_whitelisted {
+                env.storage().persistent().remove(&key);
+                removed_count += 1;
+
+                TokenWhitelistRemovedEvent {
+                    admin: admin.clone(),
+                    token: token.clone(),
+                }
+                .publish(&env);
+            }
+        }
+
+        if removed_count > 0 {
+            let mut new_whitelist = Vec::new(&env);
+            for t in whitelist.iter() {
+                if !tokens.contains(&t) {
+                    new_whitelist.push_back(t);
+                }
+            }
+            whitelist = new_whitelist;
+
+            env.storage().persistent().set(&whitelist_key, &whitelist);
+            Self::extend_persistent(&env, &whitelist_key);
+        }
+
+        Ok(removed_count)
+    }
+
     /// Add an oracle address to the trusted oracle whitelist. Caller must have Admin role (0).
     pub fn add_oracle(
         env: Env,

--- a/contract/contracts/predifi-contract/src/test.rs
+++ b/contract/contracts/predifi-contract/src/test.rs
@@ -3299,6 +3299,110 @@ fn test_multiple_tokens_whitelisted_independently() {
 }
 
 #[test]
+fn test_batch_add_tokens_to_whitelist_success() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    let token_c = Address::generate(&env);
+
+    let tokens = soroban_sdk::vec![&env, token_a.clone(), token_b.clone(), token_c.clone()];
+    let added = client.batch_add_tokens_to_whitelist(&admin, &tokens);
+
+    assert_eq!(added, 3);
+    assert!(client.is_token_allowed(&token_a));
+    assert!(client.is_token_allowed(&token_b));
+    assert!(client.is_token_allowed(&token_c));
+}
+
+#[test]
+fn test_batch_add_tokens_to_whitelist_skips_duplicates() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+
+    client.add_token_to_whitelist(&admin, &token_a);
+
+    let tokens = soroban_sdk::vec![&env, token_a.clone(), token_b.clone()];
+    let added = client.batch_add_tokens_to_whitelist(&admin, &tokens);
+
+    // Only token_b is newly added; token_a was already whitelisted.
+    assert_eq!(added, 1);
+    assert!(client.is_token_allowed(&token_a));
+    assert!(client.is_token_allowed(&token_b));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #90)")]
+fn test_batch_add_tokens_to_whitelist_empty_vector() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    let tokens: soroban_sdk::Vec<Address> = soroban_sdk::vec![&env];
+    client.batch_add_tokens_to_whitelist(&admin, &tokens);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_batch_add_tokens_to_whitelist_unauthorized() {
+    let (env, client, _admin, _treasury) = setup_whitelist_env();
+    let non_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let tokens = soroban_sdk::vec![&env, token];
+    client.batch_add_tokens_to_whitelist(&non_admin, &tokens);
+}
+
+#[test]
+fn test_batch_remove_tokens_from_whitelist_success() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    let token_c = Address::generate(&env);
+
+    let tokens = soroban_sdk::vec![&env, token_a.clone(), token_b.clone(), token_c.clone()];
+    client.batch_add_tokens_to_whitelist(&admin, &tokens);
+
+    let removed = client.batch_remove_tokens_from_whitelist(&admin, &tokens);
+
+    assert_eq!(removed, 3);
+    assert!(!client.is_token_allowed(&token_a));
+    assert!(!client.is_token_allowed(&token_b));
+    assert!(!client.is_token_allowed(&token_c));
+}
+
+#[test]
+fn test_batch_remove_tokens_from_whitelist_skips_non_whitelisted() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+
+    client.add_token_to_whitelist(&admin, &token_a);
+
+    let tokens = soroban_sdk::vec![&env, token_a.clone(), token_b.clone()];
+    let removed = client.batch_remove_tokens_from_whitelist(&admin, &tokens);
+
+    // Only token_a was actually whitelisted.
+    assert_eq!(removed, 1);
+    assert!(!client.is_token_allowed(&token_a));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #90)")]
+fn test_batch_remove_tokens_from_whitelist_empty_vector() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    let tokens: soroban_sdk::Vec<Address> = soroban_sdk::vec![&env];
+    client.batch_remove_tokens_from_whitelist(&admin, &tokens);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_batch_remove_tokens_from_whitelist_unauthorized() {
+    let (env, client, admin, _treasury) = setup_whitelist_env();
+    let non_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let tokens = soroban_sdk::vec![&env, token.clone()];
+    client.batch_add_tokens_to_whitelist(&admin, &tokens);
+    client.batch_remove_tokens_from_whitelist(&non_admin, &tokens);
+}
+
+#[test]
 #[should_panic]
 fn test_unauthorized_add_to_whitelist_panics() {
     let (env, client, _admin, _treasury) = setup_whitelist_env();

--- a/frontend/app/api/og/pool/[id]/route.tsx
+++ b/frontend/app/api/og/pool/[id]/route.tsx
@@ -1,0 +1,94 @@
+import { ImageResponse } from "next/og";
+import { fetchPoolById } from "@/lib/api/pools";
+
+export const runtime = "edge";
+
+function outcomeLabel(outcome: number, labels?: string[]): string {
+  return labels?.[outcome] ?? `Outcome ${outcome + 1}`;
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const pool = await fetchPoolById(id).catch(() => null);
+
+  if (!pool) {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            height: "100%",
+            background: "#0A0A0A",
+            color: "#fff",
+            fontSize: 48,
+          }}
+        >
+          Pool not found
+        </div>
+      ),
+      { width: 1200, height: 630 },
+    );
+  }
+
+  const topOutcomes = [...pool.odds]
+    .sort((a, b) => b.stake - a.stake)
+    .slice(0, 3);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          width: "100%",
+          height: "100%",
+          padding: 64,
+          background: "#0A0A0A",
+          color: "#fff",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <div style={{ fontSize: 28, color: "#7DE3EC", textTransform: "uppercase" }}>
+            {pool.category} · PrediFi
+          </div>
+          <div style={{ fontSize: 56, fontWeight: 700, lineHeight: 1.15 }}>
+            {pool.name}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          {topOutcomes.map((o) => (
+            <div
+              key={o.outcome}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: 32,
+                borderTop: "1px solid #27272a",
+                paddingTop: 16,
+              }}
+            >
+              <span>{outcomeLabel(o.outcome, pool.outcome_descriptions)}</span>
+              <span style={{ color: "#37B7C3", fontWeight: 700 }}>
+                {o.odds.toFixed(2)}x
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <div style={{ display: "flex", fontSize: 28, color: "#71717a" }}>
+          {pool.total_stake.toLocaleString()} {pool.token} staked
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 },
+  );
+}

--- a/frontend/app/user/leaderboard/page.tsx
+++ b/frontend/app/user/leaderboard/page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  fetchLeaderboard,
+  type LeaderboardEntry,
+  type WinningsLeaderboardEntry,
+  type LeaderboardPeriod,
+  type LeaderboardRankBy,
+} from "@/lib/api/leaderboard";
+
+const RANK_OPTIONS: { value: LeaderboardRankBy; label: string }[] = [
+  { value: "volume", label: "Volume" },
+  { value: "winnings", label: "Earnings" },
+  { value: "win_rate", label: "Win Rate" },
+  { value: "streak", label: "Streak" },
+];
+
+const PERIOD_OPTIONS: { value: LeaderboardPeriod; label: string }[] = [
+  { value: "all", label: "All-time" },
+  { value: "month", label: "Monthly" },
+  { value: "week", label: "Weekly" },
+];
+
+function shortAddress(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function isWinningsEntry(
+  entry: LeaderboardEntry | WinningsLeaderboardEntry,
+): entry is WinningsLeaderboardEntry {
+  return "total_winnings" in entry;
+}
+
+export default function LeaderboardPage() {
+  const [rankBy, setRankBy] = useState<LeaderboardRankBy>("volume");
+  const [period, setPeriod] = useState<LeaderboardPeriod>("all");
+  const [entries, setEntries] = useState<
+    (LeaderboardEntry | WinningsLeaderboardEntry)[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Time-window filtering only applies to volume/win_rate/streak.
+  const periodDisabled = rankBy === "winnings";
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    fetchLeaderboard({ rankBy, period: periodDisabled ? undefined : period, limit: 50 })
+      .then((res) => {
+        if (cancelled) return;
+        setEntries(res.leaderboard);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load leaderboard.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [rankBy, period, periodDisabled]);
+
+  return (
+    <div className="min-h-screen bg-[#0A0A0A] p-6 lg:p-8">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold text-white">Leaderboard</h1>
+          <p className="text-zinc-400 text-sm">
+            Top predictors ranked by volume, earnings, win rate, and streak.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap gap-2">
+            {RANK_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setRankBy(opt.value)}
+                className={cn(
+                  "rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                  rankBy === opt.value
+                    ? "border-[#37B7C3] bg-[#37B7C3]/10 text-[#7DE3EC]"
+                    : "border-zinc-800 text-zinc-400 hover:text-white",
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex gap-2">
+            {PERIOD_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                disabled={periodDisabled}
+                onClick={() => setPeriod(opt.value)}
+                className={cn(
+                  "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+                  periodDisabled && "cursor-not-allowed opacity-40",
+                  !periodDisabled && period === opt.value
+                    ? "border-zinc-500 bg-zinc-800 text-white"
+                    : "border-zinc-800 text-zinc-500 hover:text-white",
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900">
+          {isLoading ? (
+            <div className="p-8 text-center text-sm text-zinc-500">
+              Loading leaderboard…
+            </div>
+          ) : error ? (
+            <div className="p-8 text-center text-sm text-red-400">{error}</div>
+          ) : entries.length === 0 ? (
+            <div className="p-8 text-center text-sm text-zinc-500">
+              No rankings yet for this view.
+            </div>
+          ) : (
+            <ul className="divide-y divide-zinc-800">
+              {entries.map((entry) => (
+                <li
+                  key={entry.user_address}
+                  className="flex items-center justify-between gap-4 px-5 py-3.5"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="w-6 shrink-0 text-sm font-semibold text-zinc-500 tabular-nums">
+                      #{entry.rank}
+                    </span>
+                    <span className="truncate text-sm font-medium text-white">
+                      {shortAddress(entry.user_address)}
+                    </span>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-4 text-sm tabular-nums">
+                    {isWinningsEntry(entry) ? (
+                      <>
+                        <span className="text-white font-semibold">
+                          {entry.total_winnings.toLocaleString()}
+                        </span>
+                        <span className="text-zinc-500">
+                          {(entry.win_rate * 100).toFixed(0)}% win rate
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <span className="text-white font-semibold">
+                          {rankBy === "volume" &&
+                            entry.total_volume.toLocaleString()}
+                          {rankBy === "win_rate" &&
+                            `${(entry.win_rate * 100).toFixed(0)}%`}
+                          {rankBy === "streak" && `${entry.current_streak}🔥`}
+                        </span>
+                        <span className="text-zinc-500">
+                          {entry.prediction_count} predictions
+                        </span>
+                      </>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/user/pool-market/[id]/page.tsx
+++ b/frontend/app/user/pool-market/[id]/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { fetchPoolById } from "@/lib/api/pools";
+import { ShareButton, CopyButton } from "@/components/ui";
+
+const SITE_URL = "https://predifi.app";
+
+function formatStake(amount: number, token: string): string {
+  return `${amount.toLocaleString()} ${token}`;
+}
+
+function outcomeLabel(outcome: number, labels?: string[]): string {
+  return labels?.[outcome] ?? `Outcome ${outcome + 1}`;
+}
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const pool = await fetchPoolById(id).catch(() => null);
+
+  if (!pool) {
+    return { title: "Pool Not Found | PrediFi" };
+  }
+
+  const title = `${pool.name} | PrediFi`;
+  const topOutcome = [...pool.odds].sort((a, b) => b.stake - a.stake)[0];
+  const description = topOutcome
+    ? `${pool.category} prediction pool on PrediFi — ${formatStake(pool.total_stake, pool.token)} staked. Leading: ${outcomeLabel(topOutcome.outcome, pool.outcome_descriptions)} at ${topOutcome.odds.toFixed(2)}x odds.`
+    : `${pool.category} prediction pool on PrediFi — ${formatStake(pool.total_stake, pool.token)} staked.`;
+  const url = `${SITE_URL}/user/pool-market/${pool.pool_id}`;
+  const image = `${SITE_URL}/api/og/pool/${pool.pool_id}`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "PrediFi",
+      images: [{ url: image, width: 1200, height: 630, alt: pool.name }],
+      locale: "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
+    },
+  };
+}
+
+export default async function PoolDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const pool = await fetchPoolById(id).catch(() => null);
+
+  if (!pool) {
+    notFound();
+  }
+
+  const shareUrl = `${SITE_URL}/user/pool-market/${pool.pool_id}`;
+  const shareTitle = `${pool.name} — predict on PrediFi`;
+
+  return (
+    <div className="min-h-screen bg-[#0A0A0A] p-6 lg:p-8">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-wide text-[#7DE3EC]">
+              {pool.category}
+            </p>
+            <h1 className="text-3xl font-bold text-white">{pool.name}</h1>
+            <p className="text-sm text-zinc-500">
+              {formatStake(pool.total_stake, pool.token)} staked · {pool.state}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <CopyButton
+              text={shareUrl}
+              size="md"
+              className="rounded-md border border-zinc-700 p-2"
+              aria-label="Copy pool link"
+            />
+            <ShareButton url={shareUrl} title={shareTitle} text={pool.name} />
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-white uppercase tracking-wide">
+            Outcomes &amp; Odds
+          </h2>
+          <div className="space-y-2">
+            {pool.odds.map((o) => (
+              <div
+                key={o.outcome}
+                className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-800/40 px-4 py-3"
+              >
+                <span className="text-sm text-zinc-200">
+                  {outcomeLabel(o.outcome, pool.outcome_descriptions)}
+                  {pool.result != null &&
+                    Number(pool.result) === o.outcome && (
+                      <span className="ml-2 text-xs font-medium text-emerald-400">
+                        Winner
+                      </span>
+                    )}
+                </span>
+                <span className="text-sm font-medium text-white">
+                  {o.odds.toFixed(2)}x
+                  <span className="ml-2 text-zinc-500">
+                    ({formatStake(o.stake, pool.token)})
+                  </span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/pool/CreatePoolForm.tsx
+++ b/frontend/components/pool/CreatePoolForm.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useId } from "react";
 import { useRouter } from "next/navigation";
-import { CheckCircle2, Info } from "lucide-react";
+import { CheckCircle2, Info, Plus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button, Input, StakeInput, Checkbox, SupportedTokensPicker } from "@/components/ui";
 import type { Token } from "@/components/ui";
@@ -10,6 +10,8 @@ import {
   validateCreatePool,
   minCloseTimeValue,
   POOL_CATEGORIES,
+  MIN_OUTCOMES,
+  MAX_OUTCOMES,
   type CreatePoolFormValues,
   type CreatePoolFormErrors,
 } from "@/lib/validations/poolCreation";
@@ -20,8 +22,7 @@ const INITIAL_VALUES: CreatePoolFormValues = {
   name: "",
   description: "",
   category: "",
-  optionA: "",
-  optionB: "",
+  outcomes: ["", ""],
   minStake: "",
   maxStake: "",
   closeTime: "",
@@ -375,6 +376,44 @@ export function CreatePoolForm() {
     setSubmitError(null);
   }
 
+  function setOutcome(index: number, value: string) {
+    setValues((prev) => {
+      const outcomes = [...prev.outcomes];
+      outcomes[index] = value;
+      return { ...prev, outcomes };
+    });
+    setErrors((prev) => {
+      if (!prev.outcomeErrors && !prev.outcomes) return prev;
+      const outcomeErrors = prev.outcomeErrors ? [...prev.outcomeErrors] : undefined;
+      if (outcomeErrors) outcomeErrors[index] = undefined;
+      return { ...prev, outcomeErrors, outcomes: undefined };
+    });
+    setSubmitError(null);
+  }
+
+  function addOutcome() {
+    setValues((prev) =>
+      prev.outcomes.length >= MAX_OUTCOMES
+        ? prev
+        : { ...prev, outcomes: [...prev.outcomes, ""] },
+    );
+  }
+
+  function removeOutcome(index: number) {
+    setValues((prev) =>
+      prev.outcomes.length <= MIN_OUTCOMES
+        ? prev
+        : { ...prev, outcomes: prev.outcomes.filter((_, i) => i !== index) },
+    );
+    setErrors((prev) => {
+      if (!prev.outcomeErrors) return prev;
+      return {
+        ...prev,
+        outcomeErrors: prev.outcomeErrors.filter((_, i) => i !== index),
+      };
+    });
+  }
+
   function handleTokenChange(token: Token) {
     setValues((prev) => ({ ...prev, token: token.id }));
     // Re-validate stake fields when token changes
@@ -395,7 +434,11 @@ export function CreatePoolForm() {
       setErrors(validationErrors);
       // Scroll to the first error field
       const firstErrorField = Object.keys(validationErrors)[0];
-      const el = document.getElementById(firstErrorField);
+      const targetId =
+        firstErrorField === "outcomeErrors"
+          ? `outcome-${validationErrors.outcomeErrors?.findIndex((e) => e) ?? 0}`
+          : firstErrorField;
+      const el = document.getElementById(targetId);
       el?.scrollIntoView({ behavior: "smooth", block: "center" });
       return;
     }
@@ -486,31 +529,58 @@ export function CreatePoolForm() {
       {/* ── 2. Prediction Options ── */}
       <FormSection
         title="Prediction Options"
-        description="Define the two possible outcomes participants can stake on."
+        description={`Define the outcomes participants can stake on (${MIN_OUTCOMES}–${MAX_OUTCOMES}).`}
       >
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <Input
-            id="optionA"
-            label="Option A"
-            placeholder="e.g. Yes"
-            value={values.optionA}
-            onChange={(e) => setField("optionA", e.target.value)}
-            error={errors.optionA}
-            helperText="Up to 50 characters."
-            disabled={isSubmitting}
-            autoComplete="off"
-          />
-          <Input
-            id="optionB"
-            label="Option B"
-            placeholder="e.g. No"
-            value={values.optionB}
-            onChange={(e) => setField("optionB", e.target.value)}
-            error={errors.optionB}
-            helperText="Up to 50 characters. Must differ from Option A."
-            disabled={isSubmitting}
-            autoComplete="off"
-          />
+        <div className="space-y-3">
+          {values.outcomes.map((outcome, index) => (
+            <div key={index} className="flex items-start gap-2">
+              <div className="flex-1">
+                <Input
+                  id={`outcome-${index}`}
+                  label={`Outcome ${index + 1}`}
+                  placeholder={
+                    index === 0 ? "e.g. Yes" : index === 1 ? "e.g. No" : "e.g. Draw"
+                  }
+                  value={outcome}
+                  onChange={(e) => setOutcome(index, e.target.value)}
+                  error={errors.outcomeErrors?.[index]}
+                  disabled={isSubmitting}
+                  autoComplete="off"
+                />
+              </div>
+              {values.outcomes.length > MIN_OUTCOMES && (
+                <button
+                  type="button"
+                  onClick={() => removeOutcome(index)}
+                  disabled={isSubmitting}
+                  aria-label={`Remove outcome ${index + 1}`}
+                  className="mt-7 flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-zinc-700 text-zinc-400 hover:border-red-800 hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              )}
+            </div>
+          ))}
+
+          {errors.outcomes && (
+            <p className="text-sm font-medium text-destructive" role="alert">
+              {errors.outcomes}
+            </p>
+          )}
+
+          {values.outcomes.length < MAX_OUTCOMES && (
+            <Button
+              type="button"
+              variant="tertiary"
+              size="small"
+              onClick={addOutcome}
+              disabled={isSubmitting}
+              className="gap-1.5"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add outcome
+            </Button>
+          )}
         </div>
       </FormSection>
 

--- a/frontend/lib/api/leaderboard.ts
+++ b/frontend/lib/api/leaderboard.ts
@@ -1,0 +1,96 @@
+/**
+ * Leaderboard API client.
+ *
+ * Thin wrapper around `GET /api/v1/leaderboard` and
+ * `GET /api/v1/pools/{id}/leaderboard`.
+ */
+import { API_BASE_URL } from "@/lib/api/pools";
+
+export type LeaderboardRankBy = "volume" | "winnings" | "win_rate" | "streak";
+export type LeaderboardPeriod = "week" | "month" | "all";
+
+/** A single leaderboard row (volume / win_rate / streak ranking). */
+export interface LeaderboardEntry {
+  user_address: string;
+  total_volume: number;
+  prediction_count: number;
+  wins: number;
+  settled_count: number;
+  win_rate: number;
+  current_streak: number;
+  rank: number;
+}
+
+/** A single leaderboard row for the legacy dollar-winnings ranking. */
+export interface WinningsLeaderboardEntry {
+  user_address: string;
+  total_winnings: number;
+  winning_predictions: number;
+  total_predictions: number;
+  win_rate: number;
+  rank: number;
+}
+
+interface LeaderboardResponse<T> {
+  leaderboard: T[];
+  rank_by: string;
+  period?: string;
+  limit: number;
+  offset: number;
+}
+
+interface ApiEnvelope<T> {
+  status: "success" | "error";
+  data?: T;
+  error?: { code: string; message: string; request_id: string };
+}
+
+export interface LeaderboardQuery {
+  rankBy?: LeaderboardRankBy;
+  period?: LeaderboardPeriod;
+  limit?: number;
+  offset?: number;
+}
+
+async function unwrap<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    throw new Error(`Leaderboard request failed (HTTP ${res.status})`);
+  }
+  const body = (await res.json()) as ApiEnvelope<T> & Partial<T>;
+  // `ApiResponse::success` wraps in { status, data }; some legacy handlers
+  // (get_leaderboard for "winnings"/"volume") return the same envelope.
+  return (body.data ?? (body as unknown as T)) as T;
+}
+
+/** Fetch the global leaderboard. */
+export async function fetchLeaderboard(
+  query: LeaderboardQuery = {},
+): Promise<LeaderboardResponse<LeaderboardEntry | WinningsLeaderboardEntry>> {
+  const params = new URLSearchParams();
+  params.set("rank_by", query.rankBy ?? "volume");
+  if (query.period) params.set("period", query.period);
+  if (query.limit != null) params.set("limit", String(query.limit));
+  if (query.offset != null) params.set("offset", String(query.offset));
+
+  const res = await fetch(`${API_BASE_URL}/api/v1/leaderboard?${params}`, {
+    headers: { Accept: "application/json" },
+  });
+  return unwrap(res);
+}
+
+/** Fetch the leaderboard scoped to a single pool. */
+export async function fetchPoolLeaderboard(
+  poolId: number | string,
+  query: Omit<LeaderboardQuery, "period"> = {},
+): Promise<LeaderboardResponse<LeaderboardEntry>> {
+  const params = new URLSearchParams();
+  params.set("rank_by", query.rankBy ?? "volume");
+  if (query.limit != null) params.set("limit", String(query.limit));
+  if (query.offset != null) params.set("offset", String(query.offset));
+
+  const res = await fetch(
+    `${API_BASE_URL}/api/v1/pools/${poolId}/leaderboard?${params}`,
+    { headers: { Accept: "application/json" } },
+  );
+  return unwrap(res);
+}

--- a/frontend/lib/api/pools.ts
+++ b/frontend/lib/api/pools.ts
@@ -103,3 +103,61 @@ export async function fetchPools(url: string): Promise<PoolsResponse> {
 
   return (await res.json()) as PoolsResponse;
 }
+
+/** Per-outcome stake/odds breakdown, as returned by `GET /api/v1/pools/{id}`. */
+export interface OutcomeOdds {
+  outcome: number;
+  stake: number;
+  odds: number;
+}
+
+/** A single pool with real-time odds and (when available) outcome labels. */
+export interface PoolWithOdds {
+  pool_id: number;
+  name: string;
+  category: string;
+  total_stake: number;
+  end_time: string;
+  created_at: string;
+  state: string;
+  creator: string;
+  token: string;
+  result: string | null;
+  odds: OutcomeOdds[];
+  /** Human-readable labels for each outcome, when the indexer has them. */
+  outcome_descriptions?: string[];
+}
+
+/** Envelope shape returned by every `/api/v1` endpoint. */
+interface ApiEnvelope<T> {
+  status: "success" | "error";
+  data?: T;
+  error?: { code: string; message: string; request_id: string };
+}
+
+/** Build the URL for `GET /api/v1/pools/{id}`. */
+export function poolByIdUrl(poolId: number | string): string {
+  return `${API_BASE_URL}/api/v1/pools/${poolId}`;
+}
+
+/**
+ * Fetch a single pool with its current odds by id.
+ *
+ * Returns `null` on a 404 (pool not found) so callers can render a
+ * "not found" state; throws {@link ApiError} for other non-2xx statuses.
+ */
+export async function fetchPoolById(
+  poolId: number | string,
+): Promise<PoolWithOdds | null> {
+  const res = await fetch(poolByIdUrl(poolId), {
+    headers: { Accept: "application/json" },
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new ApiError(`Failed to load pool (HTTP ${res.status})`, res.status);
+  }
+
+  const body = (await res.json()) as ApiEnvelope<PoolWithOdds>;
+  return body.data ?? null;
+}

--- a/frontend/lib/validations/poolCreation.ts
+++ b/frontend/lib/validations/poolCreation.ts
@@ -31,6 +31,12 @@ export const MAX_STAKE: Record<string, number> = {
   STRK: 1_000_000,
 };
 
+/** Minimum number of outcomes a pool must define. */
+export const MIN_OUTCOMES = 2;
+
+/** Maximum number of outcomes a pool may define (mirrors the on-chain MAX_OPTIONS_COUNT). */
+export const MAX_OUTCOMES = 10;
+
 /** Form field values for pool creation. */
 export interface CreatePoolFormValues {
   /** Human-readable pool name. */
@@ -39,10 +45,12 @@ export interface CreatePoolFormValues {
   description: string;
   /** Category bucket this pool belongs to. */
   category: PoolCategory | "";
-  /** Option A label (e.g. "Yes", "Team A wins"). */
-  optionA: string;
-  /** Option B label (e.g. "No", "Team B wins"). */
-  optionB: string;
+  /**
+   * Labels for each possible outcome (e.g. `["Yes", "No"]` or
+   * `["Team A", "Team B", "Draw"]`). Must contain between
+   * {@link MIN_OUTCOMES} and {@link MAX_OUTCOMES} non-empty, unique entries.
+   */
+  outcomes: string[];
   /** Minimum stake required to participate (display units). */
   minStake: string;
   /** Maximum stake per participant (display units). */
@@ -58,7 +66,10 @@ export interface CreatePoolFormValues {
 /** Per-field validation error messages. */
 export type CreatePoolFormErrors = Partial<
   Record<keyof CreatePoolFormValues, string>
->;
+> & {
+  /** Per-outcome error messages, indexed the same as `values.outcomes`. */
+  outcomeErrors?: (string | undefined)[];
+};
 
 /** Minimum minutes a pool close time must be in the future. */
 const MIN_CLOSE_MINUTES = 30;
@@ -99,28 +110,33 @@ export function validateCreatePool(
     errors.category = "Please select a category.";
   }
 
-  // ── options ───────────────────────────────────────────────────────────────
-  const optionA = values.optionA.trim();
-  const optionB = values.optionB.trim();
+  // ── outcomes ──────────────────────────────────────────────────────────────
+  const outcomeErrors: (string | undefined)[] = values.outcomes.map(
+    (outcome) => {
+      const trimmed = outcome.trim();
+      if (!trimmed) return "Outcome label is required.";
+      if (trimmed.length > 50) return "Must be 50 characters or fewer.";
+      return undefined;
+    },
+  );
 
-  if (!optionA) {
-    errors.optionA = "Option A label is required.";
-  } else if (optionA.length < 1) {
-    errors.optionA = "Option A must not be empty.";
-  } else if (optionA.length > 50) {
-    errors.optionA = "Option A must be 50 characters or fewer.";
+  const trimmedOutcomes = values.outcomes.map((o) => o.trim().toLowerCase());
+  trimmedOutcomes.forEach((outcome, index) => {
+    if (!outcome || outcomeErrors[index]) return;
+    const firstDuplicateIndex = trimmedOutcomes.indexOf(outcome);
+    if (firstDuplicateIndex !== index) {
+      outcomeErrors[index] = "Outcome labels must be unique.";
+    }
+  });
+
+  if (outcomeErrors.some((e) => e !== undefined)) {
+    errors.outcomeErrors = outcomeErrors;
   }
 
-  if (!optionB) {
-    errors.optionB = "Option B label is required.";
-  } else if (optionB.length < 1) {
-    errors.optionB = "Option B must not be empty.";
-  } else if (optionB.length > 50) {
-    errors.optionB = "Option B must be 50 characters or fewer.";
-  }
-
-  if (optionA && optionB && optionA.toLowerCase() === optionB.toLowerCase()) {
-    errors.optionB = "Option B must be different from Option A.";
+  if (values.outcomes.length < MIN_OUTCOMES) {
+    errors.outcomes = `A pool needs at least ${MIN_OUTCOMES} outcomes.`;
+  } else if (values.outcomes.length > MAX_OUTCOMES) {
+    errors.outcomes = `A pool can have at most ${MAX_OUTCOMES} outcomes.`;
   }
 
   // ── stake bounds ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Contract**: `batch_add_tokens_to_whitelist` / `batch_remove_tokens_from_whitelist` admin functions to whitelist/de-whitelist multiple tokens in one transaction, mirroring the existing `batch_add_to_whitelist` pattern. Closes #1367
- **Multi-outcome pools**: the contract already supports N-way outcomes (`options_count` / `outcome_descriptions`); the frontend `CreatePoolForm` was hard-coded to a binary Option A / Option B. Replaced with a dynamic 2–10 outcome list (add/remove, per-outcome validation, uniqueness checks), and extended the pool API client/types to carry `outcome_descriptions`. Closes #1365
- **Leaderboard**: `GET /api/v1/leaderboard` now supports `rank_by=win_rate|streak` and `period=week|month|all` time windows, plus a new `GET /api/v1/pools/:id/leaderboard` for pool-specific rankings. Added a frontend leaderboard page with rank/period toggles. Closes #1363
- **Social sharing**: new dynamic pool detail page (`/user/pool-market/[id]`) with `generateMetadata` Open Graph/Twitter tags, a generated share-card image at `/api/og/pool/[id]` (odds + pool details), and the existing `ShareButton`/`CopyButton` components wired up for X, Telegram, and direct link copying. Closes #1364

## Test plan

- [ ] `cd contract && cargo test -p predifi-contract` — new `test_batch_add_tokens_to_whitelist_*` / `test_batch_remove_tokens_from_whitelist_*` tests
- [ ] `cd backend && cargo build` — new `get_leaderboard_extended` query and `/pools/:id/leaderboard` route
- [ ] `cd frontend && npm run build` — new pool detail page, OG image route, leaderboard page, and updated `CreatePoolForm`
- [ ] Manually create a pool with 3+ outcomes and confirm submission/validation
- [ ] Manually load `/user/pool-market/:id` and confirm OG tags / share card render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)