### PR TITLE
test: add integration and edge-case tests for oracle, lifecycle, referral, and fee tiers

### DIFF
--- a/contract/contracts/predifi-contract/src/fee_tier_transition_tests.rs
+++ b/contract/contracts/predifi-contract/src/fee_tier_transition_tests.rs
@@ -1,0 +1,227 @@
+//! Fee tier transition integration tests (Issue #1335).
+//!
+//! Covers: fee applied below/at/above tier thresholds, multiple tiers,
+//! and treasury accumulation across several pools.
+
+#![cfg(test)]
+
+use crate::test::ROLE_ADMIN;
+use crate::{FeeTier, PoolConfig};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    token, vec, Address, Env, String, Vec,
+};
+
+fn create_pool(
+    env: &Env,
+    client: &crate::PredifiContractClient,
+    creator: &Address,
+    token_address: &Address,
+    end_time: u64,
+) -> u64 {
+    client.create_pool(
+        creator,
+        &end_time,
+        token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(env, "Fee tier test pool"),
+            metadata_url: String::from_str(env, "ipfs://fee-tier"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0i128,
+            min_total_stake: 1i128,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: vec![
+                env,
+                String::from_str(env, "No"),
+                String::from_str(env, "Yes"),
+            ],
+        },
+    )
+}
+
+/// Pool with total stake below the tier threshold uses the base fee.
+/// Pool above the threshold uses the reduced tier fee.
+#[test]
+fn test_fee_tier_boundary_below_and_above_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let (ac_client, client, token_address, token, token_admin_client, _treasury, operator, creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    // Base fee 3% (300 bps). Tier: stake >= 10_000 → 1% (100 bps).
+    client.set_fee_bps(&admin, &300u32);
+    env.ledger()
+        .with_mut(|li| li.timestamp += crate::FEE_CHANGE_TIMELOCK_SECONDS + 1);
+    client.apply_fee_bps(&admin);
+
+    let tiers = Vec::from_array(
+        &env,
+        [FeeTier {
+            stake_threshold: 10_000i128,
+            fee_bps: 100,
+        }],
+    );
+    client.set_fee_tiers(&admin, &tiers);
+
+    // ── Pool A: 500 stake — below threshold, base fee applies (3%).
+    let bettor_a = Address::generate(&env);
+    token_admin_client.mint(&bettor_a, &500);
+
+    let now = env.ledger().timestamp();
+    let pool_a = create_pool(&env, &client, &creator, &token_address, now + 4_000);
+    client.place_prediction(&bettor_a, &pool_a, &500, &0, &None, &None);
+
+    env.ledger().with_mut(|li| li.timestamp = now + 4_001);
+    client.resolve_pool(&operator, &pool_a, &0u32);
+
+    // fee = 3% of 500 = 15; payout = 485.
+    let winnings_a = client.claim_winnings(&bettor_a, &pool_a);
+    assert_eq!(winnings_a, 485);
+    assert_eq!(token.balance(&bettor_a), 485);
+
+    // ── Pool B: 15_000 stake — above threshold, tier fee applies (1%).
+    let bettor_b = Address::generate(&env);
+    token_admin_client.mint(&bettor_b, &15_000);
+
+    let now2 = env.ledger().timestamp();
+    let pool_b = create_pool(&env, &client, &creator, &token_address, now2 + 4_000);
+    client.place_prediction(&bettor_b, &pool_b, &15_000, &0, &None, &None);
+
+    env.ledger().with_mut(|li| li.timestamp = now2 + 4_001);
+    client.resolve_pool(&operator, &pool_b, &0u32);
+
+    // fee = 1% of 15000 = 150; payout = 14850.
+    let winnings_b = client.claim_winnings(&bettor_b, &pool_b);
+    assert_eq!(winnings_b, 14_850);
+    assert_eq!(token.balance(&bettor_b), 14_850);
+}
+
+/// Treasury accumulates fees from multiple pools.
+#[test]
+fn test_treasury_accumulation_across_pools() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let ac_id = env.register(
+        crate::test::dummy_access_control::DummyAccessControl,
+        (),
+    );
+    let ac_client =
+        crate::test::dummy_access_control::DummyAccessControlClient::new(&env, &ac_id);
+
+    let contract_id = env.register(crate::PredifiContract, ());
+    let client = crate::PredifiContractClient::new(&env, &contract_id);
+
+    let token_admin_addr = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract(token_admin_addr.clone());
+    let tok = token::Client::new(&env, &token_contract);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract);
+    let token_address = token_contract;
+
+    let treasury = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    ac_client.grant_role(&operator, &crate::test::ROLE_OPERATOR);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    // 2% base fee, no tiers.
+    client.init(&ac_id, &treasury, &200u32, &0u64, &3600u64, &0u32);
+    client.add_token_to_whitelist(&admin, &token_address);
+
+    let bettor1 = Address::generate(&env);
+    let bettor2 = Address::generate(&env);
+    token_admin_client.mint(&bettor1, &1_000);
+    token_admin_client.mint(&bettor2, &2_000);
+
+    let now = env.ledger().timestamp();
+
+    // Pool 1: 1000 stake → fee = 20.
+    let pool1 = create_pool(&env, &client, &creator, &token_address, now + 4_000);
+    client.place_prediction(&bettor1, &pool1, &1_000, &0, &None, &None);
+    env.ledger().with_mut(|li| li.timestamp = now + 4_001);
+    client.resolve_pool(&operator, &pool1, &0u32);
+    client.claim_winnings(&bettor1, &pool1);
+
+    // Pool 2: 2000 stake → fee = 40.
+    let now2 = env.ledger().timestamp();
+    let pool2 = create_pool(&env, &client, &creator, &token_address, now2 + 4_000);
+    client.place_prediction(&bettor2, &pool2, &2_000, &0, &None, &None);
+    env.ledger().with_mut(|li| li.timestamp = now2 + 4_001);
+    client.resolve_pool(&operator, &pool2, &0u32);
+    client.claim_winnings(&bettor2, &pool2);
+
+    // Contract holds exactly 20 + 40 = 60 tokens of accumulated fees.
+    assert_eq!(tok.balance(&client.address), 60);
+
+    // Admin withdraws all accumulated fees.
+    let recipient = Address::generate(&env);
+    client.withdraw_treasury(&admin, &token_address, &60, &recipient);
+    assert_eq!(tok.balance(&recipient), 60);
+    assert_eq!(tok.balance(&client.address), 0);
+}
+
+/// Two-tier config: stake in the middle tier pays the correct rate.
+#[test]
+fn test_two_tier_fee_rates() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let (ac_client, client, token_address, token, token_admin_client, _treasury, operator, creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    // Base 5% (500 bps).
+    // Tier 1: stake >= 1_000  → 2% (200 bps).
+    // Tier 2: stake >= 10_000 → 1% (100 bps).
+    client.set_fee_bps(&admin, &500u32);
+    env.ledger()
+        .with_mut(|li| li.timestamp += crate::FEE_CHANGE_TIMELOCK_SECONDS + 1);
+    client.apply_fee_bps(&admin);
+
+    let tiers = Vec::from_array(
+        &env,
+        [
+            FeeTier { stake_threshold: 1_000i128, fee_bps: 200 },
+            FeeTier { stake_threshold: 10_000i128, fee_bps: 100 },
+        ],
+    );
+    client.set_fee_tiers(&admin, &tiers);
+
+    // Mid-tier stake (5_000): tier 1 applies → 2% fee.
+    let bettor = Address::generate(&env);
+    token_admin_client.mint(&bettor, &5_000);
+
+    let now = env.ledger().timestamp();
+    let pool = create_pool(&env, &client, &creator, &token_address, now + 4_000);
+    client.place_prediction(&bettor, &pool, &5_000, &0, &None, &None);
+
+    env.ledger().with_mut(|li| li.timestamp = now + 4_001);
+    client.resolve_pool(&operator, &pool, &0u32);
+
+    // fee = 2% of 5000 = 100; payout = 4900.
+    let winnings = client.claim_winnings(&bettor, &pool);
+    assert_eq!(winnings, 4_900);
+    assert_eq!(token.balance(&bettor), 4_900);
+}

--- a/contract/contracts/predifi-contract/src/lib.rs
+++ b/contract/contracts/predifi-contract/src/lib.rs
@@ -6249,6 +6249,10 @@ impl PredifiContract {
 
 mod boundary_tests;
 mod edge_case_tests;
+mod fee_tier_transition_tests;
 mod fee_tiers_test;
 mod integration_test;
+mod lifecycle_integration_tests;
+mod oracle_edge_case_tests;
+mod referral_integration_tests;
 mod test;

--- a/contract/contracts/predifi-contract/src/lifecycle_integration_tests.rs
+++ b/contract/contracts/predifi-contract/src/lifecycle_integration_tests.rs
@@ -1,0 +1,183 @@
+//! Full pool lifecycle integration tests with balance verification (Issue #1333).
+
+#![cfg(test)]
+
+use crate::test::ROLE_ADMIN;
+use crate::PoolConfig;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    token, vec, Address, Env, String,
+};
+
+/// init → create_pool → place_prediction → close_staking → mark_pool_ready
+/// → resolve_pool → claim_winnings
+/// Verifies token balances at every stage (0% protocol fee).
+#[test]
+fn test_pool_full_lifecycle_with_balance_verification() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let (ac_client, client, token_address, token, token_admin_client, _treasury, operator, creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let bettor_a = Address::generate(&env);
+    let bettor_b = Address::generate(&env);
+
+    token_admin_client.mint(&bettor_a, &500);
+    token_admin_client.mint(&bettor_b, &300);
+
+    // 1. Create pool (ends at timestamp 5000, min_pool_duration = 3600; 1000+3600 = 4600 < 5000).
+    let end_time = 5_000u64;
+    let pool_id = client.create_pool(
+        &creator,
+        &end_time,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(&env, "Lifecycle test pool"),
+            metadata_url: String::from_str(&env, "ipfs://lifecycle"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0i128,
+            min_total_stake: 1i128,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: vec![
+                &env,
+                String::from_str(&env, "No"),
+                String::from_str(&env, "Yes"),
+            ],
+        },
+    );
+
+    // 2. Place predictions.
+    client.place_prediction(&bettor_a, &pool_id, &500, &0, &None, &None);
+    client.place_prediction(&bettor_b, &pool_id, &300, &1, &None, &None);
+
+    // Contract holds all staked tokens.
+    assert_eq!(token.balance(&client.address), 800);
+    assert_eq!(token.balance(&bettor_a), 0);
+    assert_eq!(token.balance(&bettor_b), 0);
+
+    // 3. Advance past end_time and close staking.
+    env.ledger().with_mut(|li| li.timestamp = 5_001);
+    client.close_staking(&pool_id);
+
+    // 4. Signal pool is ready for resolution.
+    client.mark_pool_ready(&pool_id);
+
+    // 5. Resolve — outcome 0 wins.
+    client.resolve_pool(&operator, &pool_id, &0u32);
+
+    // 6. Bettor A (winner) claims: (500/500) * 800 = 800.
+    let winnings_a = client.claim_winnings(&bettor_a, &pool_id);
+    assert_eq!(winnings_a, 800);
+    assert_eq!(token.balance(&bettor_a), 800);
+
+    // 7. Bettor B (loser) claims 0.
+    let winnings_b = client.claim_winnings(&bettor_b, &pool_id);
+    assert_eq!(winnings_b, 0);
+    assert_eq!(token.balance(&bettor_b), 0);
+
+    // 8. Contract is empty after all claims (0% protocol fee).
+    assert_eq!(token.balance(&client.address), 0);
+}
+
+/// Full lifecycle with a 2% protocol fee; verifies treasury accumulates the
+/// expected fee and withdraw_treasury transfers it to a recipient.
+#[test]
+fn test_pool_lifecycle_with_fee_and_treasury_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let ac_id = env.register(
+        crate::test::dummy_access_control::DummyAccessControl,
+        (),
+    );
+    let ac_client =
+        crate::test::dummy_access_control::DummyAccessControlClient::new(&env, &ac_id);
+
+    let contract_id = env.register(crate::PredifiContract, ());
+    let client = crate::PredifiContractClient::new(&env, &contract_id);
+
+    let token_admin_addr = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract(token_admin_addr.clone());
+    let token = token::Client::new(&env, &token_contract);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract);
+    let token_address = token_contract;
+
+    let treasury = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    ac_client.grant_role(&operator, &crate::test::ROLE_OPERATOR);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    // Init with 2% (200 bps) protocol fee.
+    client.init(&ac_id, &treasury, &200u32, &0u64, &3600u64, &0u32);
+    client.add_token_to_whitelist(&admin, &token_address);
+
+    let bettor = Address::generate(&env);
+    token_admin_client.mint(&bettor, &1_000);
+
+    let end_time = 5_000u64;
+    let pool_id = client.create_pool(
+        &creator,
+        &end_time,
+        &token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(&env, "Fee lifecycle pool"),
+            metadata_url: String::from_str(&env, "ipfs://fee-lifecycle"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0i128,
+            min_total_stake: 1i128,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: vec![
+                &env,
+                String::from_str(&env, "No"),
+                String::from_str(&env, "Yes"),
+            ],
+        },
+    );
+
+    // Single bettor on outcome 0; fee = 2% of 1000 = 20; payout = 980.
+    client.place_prediction(&bettor, &pool_id, &1_000, &0, &None, &None);
+
+    env.ledger().with_mut(|li| li.timestamp = 5_001);
+    client.close_staking(&pool_id);
+    client.mark_pool_ready(&pool_id);
+    client.resolve_pool(&operator, &pool_id, &0u32);
+
+    let winnings = client.claim_winnings(&bettor, &pool_id);
+    assert_eq!(winnings, 980);
+    assert_eq!(token.balance(&bettor), 980);
+
+    // Contract still holds the 20-token fee.
+    assert_eq!(token.balance(&client.address), 20);
+
+    // Treasury withdrawal transfers fee to a recipient.
+    let recipient = Address::generate(&env);
+    client.withdraw_treasury(&admin, &token_address, &20, &recipient);
+    assert_eq!(token.balance(&recipient), 20);
+    assert_eq!(token.balance(&client.address), 0);
+}

--- a/contract/contracts/predifi-contract/src/oracle_edge_case_tests.rs
+++ b/contract/contracts/predifi-contract/src/oracle_edge_case_tests.rs
@@ -1,0 +1,121 @@
+//! Edge-case and boundary tests for `add_oracle` / `remove_oracle` (Issue #1321).
+
+#![cfg(test)]
+
+use crate::test::ROLE_ADMIN;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test_add_oracle_idempotent_no_duplicate_in_list() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, _token_address, _token, _token_admin, _treasury, _operator, _creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let oracle = Address::generate(&env);
+
+    // Add the same oracle twice — both calls must succeed (idempotent).
+    client.add_oracle(&admin, &oracle);
+    client.add_oracle(&admin, &oracle);
+    // A third add still succeeds without error.
+    client.add_oracle(&admin, &oracle);
+}
+
+#[test]
+fn test_add_and_remove_single_oracle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, _token_address, _token, _token_admin, _treasury, _operator, _creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let oracle = Address::generate(&env);
+
+    client.add_oracle(&admin, &oracle);
+    // Removing the only oracle should succeed — empty list is valid.
+    client.remove_oracle(&admin, &oracle);
+    // Re-adding after removal must also succeed.
+    client.add_oracle(&admin, &oracle);
+}
+
+#[test]
+fn test_add_multiple_oracles_and_remove_middle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, _token_address, _token, _token_admin, _treasury, _operator, _creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let oracle1 = Address::generate(&env);
+    let oracle2 = Address::generate(&env);
+    let oracle3 = Address::generate(&env);
+
+    client.add_oracle(&admin, &oracle1);
+    client.add_oracle(&admin, &oracle2);
+    client.add_oracle(&admin, &oracle3);
+
+    // Remove the middle oracle; remaining two should still be manageable.
+    client.remove_oracle(&admin, &oracle2);
+    client.remove_oracle(&admin, &oracle1);
+    client.remove_oracle(&admin, &oracle3);
+}
+
+#[test]
+fn test_remove_non_existent_oracle_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, _token_address, _token, _token_admin, _treasury, _operator, _creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let never_added = Address::generate(&env);
+    // Removing an oracle that was never added must not panic.
+    client.remove_oracle(&admin, &never_added);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_add_oracle_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_ac_client, client, _token_address, _token, _token_admin, _treasury, _operator, _creator) =
+        crate::test::setup(&env);
+
+    // Random address with no role — must be rejected with Unauthorized (#10).
+    let non_admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    client.add_oracle(&non_admin, &oracle);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_remove_oracle_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (ac_client, client, _token_address, _token, _token_admin, _treasury, _operator, _creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+    let oracle = Address::generate(&env);
+    client.add_oracle(&admin, &oracle);
+
+    // A non-admin attempting removal must be rejected.
+    let non_admin = Address::generate(&env);
+    client.remove_oracle(&non_admin, &oracle);
+}

--- a/contract/contracts/predifi-contract/src/referral_integration_tests.rs
+++ b/contract/contracts/predifi-contract/src/referral_integration_tests.rs
@@ -1,0 +1,184 @@
+//! Referral system end-to-end integration tests (Issue #1334).
+//!
+//! Covers: referrer registration via place_prediction, volume tracking,
+//! referral cut calculation, and self-referral rejection.
+
+#![cfg(test)]
+
+use crate::test::ROLE_ADMIN;
+use crate::PoolConfig;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    token, vec, Address, Env, String,
+};
+
+fn make_pool(
+    env: &Env,
+    client: &crate::PredifiContractClient,
+    creator: &Address,
+    token_address: &Address,
+    end_time: u64,
+) -> u64 {
+    client.create_pool(
+        creator,
+        &end_time,
+        token_address,
+        &2u32,
+        &symbol_short!("Tech"),
+        &PoolConfig {
+            start_time: 0,
+            description: String::from_str(env, "Referral test pool"),
+            metadata_url: String::from_str(env, "ipfs://referral"),
+            min_stake: 1i128,
+            max_stake: 0i128,
+            max_total_stake: 0i128,
+            min_total_stake: 1i128,
+            initial_liquidity: 0i128,
+            required_resolutions: 1u32,
+            private: false,
+            whitelist_key: None,
+            outcome_descriptions: vec![
+                env,
+                String::from_str(env, "No"),
+                String::from_str(env, "Yes"),
+            ],
+        },
+    )
+}
+
+/// Placing predictions with a referrer accumulates volume for that referrer.
+#[test]
+fn test_referral_volume_tracking() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let (ac_client, client, token_address, _token, token_admin_client, _treasury, _operator, creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let referrer = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    token_admin_client.mint(&user_a, &300);
+    token_admin_client.mint(&user_b, &200);
+
+    let pool_id = make_pool(&env, &client, &creator, &token_address, 5_000);
+
+    client.place_prediction(&user_a, &pool_id, &300, &0, &Some(referrer.clone()), &None);
+    assert_eq!(client.get_referred_volume(&referrer, &pool_id), 300);
+
+    client.place_prediction(&user_b, &pool_id, &200, &1, &Some(referrer.clone()), &None);
+    assert_eq!(client.get_referred_volume(&referrer, &pool_id), 500);
+}
+
+/// Referral cut is paid to the referrer on claim_winnings.
+#[test]
+fn test_referral_cut_paid_on_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let ac_id = env.register(
+        crate::test::dummy_access_control::DummyAccessControl,
+        (),
+    );
+    let ac_client =
+        crate::test::dummy_access_control::DummyAccessControlClient::new(&env, &ac_id);
+
+    let contract_id = env.register(crate::PredifiContract, ());
+    let client = crate::PredifiContractClient::new(&env, &contract_id);
+
+    let token_admin_addr = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract(token_admin_addr.clone());
+    let token = token::Client::new(&env, &token_contract);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract);
+    let token_address = token_contract;
+
+    let treasury = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    ac_client.grant_role(&operator, &crate::test::ROLE_OPERATOR);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    // 2% protocol fee; 50% of that goes to the referrer.
+    client.init(&ac_id, &treasury, &200u32, &0u64, &3600u64, &0u32);
+    client.add_token_to_whitelist(&admin, &token_address);
+    client.set_referral_cut_bps(&admin, &5000u32);
+
+    let referrer = Address::generate(&env);
+    let referred = Address::generate(&env);
+
+    token_admin_client.mint(&referred, &1_000);
+
+    let pool_id = make_pool(&env, &client, &creator, &token_address, 5_000);
+
+    client.place_prediction(&referred, &pool_id, &1_000, &0, &Some(referrer.clone()), &None);
+
+    assert_eq!(client.get_referred_volume(&referrer, &pool_id), 1_000);
+
+    env.ledger().with_mut(|li| li.timestamp = 5_001);
+    client.resolve_pool(&operator, &pool_id, &0u32);
+
+    // Protocol fee = 2% of 1000 = 20. Referrer cut = 50% of 20 = 10. Payout = 980.
+    let winnings = client.claim_winnings(&referred, &pool_id);
+    assert_eq!(winnings, 980);
+    assert_eq!(token.balance(&referred), 980);
+    assert_eq!(token.balance(&referrer), 10);
+}
+
+/// A user must not be able to refer themselves.
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_update_referrer_self_referral_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let (_ac_client, client, token_address, _token, token_admin_client, _treasury, _operator, creator) =
+        crate::test::setup(&env);
+
+    let user = Address::generate(&env);
+    token_admin_client.mint(&user, &100);
+
+    let pool_id = make_pool(&env, &client, &creator, &token_address, 5_000);
+
+    client.update_referrer(&user, &pool_id, &Some(user.clone()));
+}
+
+/// Referred volume is scoped per-pool; different pools have independent counts.
+#[test]
+fn test_referral_volume_is_per_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let (ac_client, client, token_address, _token, token_admin_client, _treasury, _operator, creator) =
+        crate::test::setup(&env);
+
+    let admin = Address::generate(&env);
+    ac_client.grant_role(&admin, &ROLE_ADMIN);
+
+    let referrer = Address::generate(&env);
+    let user = Address::generate(&env);
+    token_admin_client.mint(&user, &600);
+
+    let pool_a = make_pool(&env, &client, &creator, &token_address, 5_000);
+    let pool_b = make_pool(&env, &client, &creator, &token_address, 5_000);
+
+    client.place_prediction(&user, &pool_a, &400, &0, &Some(referrer.clone()), &None);
+    client.place_prediction(&user, &pool_b, &200, &0, &Some(referrer.clone()), &None);
+
+    assert_eq!(client.get_referred_volume(&referrer, &pool_a), 400);
+    assert_eq!(client.get_referred_volume(&referrer, &pool_b), 200);
+}


### PR DESCRIPTION
Closes #1321
Closes #1333
Closes #1334
Closes #1335

Adds four new Soroban test modules covering previously untested contract behaviour:

- **oracle_edge_case_tests.rs** (#1321): idempotent `add_oracle`, single/multi-oracle removal, remove-nonexistent, non-admin rejection for both add and remove.
- **lifecycle_integration_tests.rs** (#1333): full pool lifecycle (create→predict→close_staking→mark_pool_ready→resolve→claim) with balance verification at each step; second test adds a 2% fee and verifies `withdraw_treasury`.
- **referral_integration_tests.rs** (#1334): volume accumulation across multiple predictors, referral cut paid on claim, self-referral rejection via `update_referrer`, per-pool volume scoping.
- **fee_tier_transition_tests.rs** (#1335): base vs tier fee below/above threshold, two-tier rate selection, treasury accumulation across pools verified with `withdraw_treasury`.